### PR TITLE
Etmp Data Import refactoring

### DIFF
--- a/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala
+++ b/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala
@@ -1,11 +1,13 @@
 package uk.gov.hmrc.eeitt.controllers
 
 import play.api.libs.json.Json
+import play.api.libs.openid.Errors.AUTH_CANCEL
 import play.api.mvc.Action
 import reactivemongo.api.commands.MultiBulkWriteResult
+import uk.gov.hmrc.eeitt.model.EtmpAgent
 import uk.gov.hmrc.eeitt.repositories._
 import uk.gov.hmrc.play.microservice.controller.BaseController
-import uk.gov.hmrc.eeitt.services.{ EtmpAgentParser, EtmpBusinessUserParser }
+import uk.gov.hmrc.eeitt.services.{ EtmpAgentRecordParser, EtmpBusinessUserParser }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -18,9 +20,13 @@ trait EtmpDataLoaderController extends BaseController {
 
   def loadBusinessUsers = load(EtmpBusinessUserParser.parseFile, businessUserRepo.replaceAll)
 
-  def loadAgents = load(EtmpAgentParser.parseFile, agentRepo.replaceAll)
+  def loadAgents = {
+    val parseRecords = EtmpAgentRecordParser.parseFile _
+    val textToEtmpAgents = parseRecords.andThen(EtmpAgent.fromRecords)
+    load(textToEtmpAgents, agentRepo.replaceAll)
+  }
 
-  def load[A](parseFile: String => List[A], replaceAll: Seq[A] => Future[MultiBulkWriteResult]) =
+  def load[A](parseFile: String => Seq[A], replaceAll: Seq[A] => Future[MultiBulkWriteResult]) =
     Action.async(parse.tolerantText) { implicit request =>
       val records = parseFile(request.body)
       val expectedNumberOfInserts = records.size
@@ -35,7 +41,7 @@ trait EtmpDataLoaderController extends BaseController {
             )
           )
         }
-      }
+      } // todo recover from exception inside of the parser
     }
 
 }

--- a/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala
+++ b/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala
@@ -5,10 +5,12 @@ import play.api.mvc.Action
 import reactivemongo.api.commands.MultiBulkWriteResult
 import uk.gov.hmrc.eeitt.repositories._
 import uk.gov.hmrc.eeitt.services.{ EtmpDataParser, LineParsingException }
+import uk.gov.hmrc.eeitt.utils.NonFatalWithLogging
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
 
 trait EtmpDataLoaderController extends BaseController {
 
@@ -22,21 +24,27 @@ trait EtmpDataLoaderController extends BaseController {
 
   def load[A](parseFile: String => Seq[A], replaceAll: Seq[A] => Future[MultiBulkWriteResult]) =
     Action.async(parse.tolerantText) { implicit request =>
-      val records = parseFile(request.body)
-      val expectedNumberOfInserts = records.size
-      replaceAll(records).map { writeResult =>
-        if (writeResult.ok && writeResult.n == expectedNumberOfInserts) {
-          Created(Json.obj("message" -> s"$expectedNumberOfInserts unique objects imported successfully"))
-        } else {
-          InternalServerError(
-            Json.obj(
-              "message" -> s"Failed to replace existing records with $expectedNumberOfInserts new ones",
-              "details" -> writeResult.toString
-            )
-          )
-        }
-      }.recover {
-        case LineParsingException(msg) => InternalServerError(Json.obj("message" -> msg))
+      Try(parseFile(request.body)) match {
+        case Success(records) =>
+          replaceAll(records).map { writeResult =>
+            val expectedNumberOfInserts = records.size
+            if (writeResult.ok && writeResult.n == expectedNumberOfInserts) {
+              Created(Json.obj("message" -> s"$expectedNumberOfInserts unique objects imported successfully"))
+            } else {
+              InternalServerError(
+                Json.obj(
+                  "message" -> s"Failed to replace existing records with $expectedNumberOfInserts new ones",
+                  "details" -> writeResult.toString
+                )
+              )
+            }
+          }
+
+        case Failure(LineParsingException(msg)) =>
+          Future.successful(BadRequest(Json.obj("message" -> msg)))
+
+        case Failure(NonFatalWithLogging(e)) =>
+          Future.successful(InternalServerError(Json.obj("message" -> e.getMessage)))
       }
     }
 

--- a/app/uk/gov/hmrc/eeitt/model/EtmpBusinessUser.scala
+++ b/app/uk/gov/hmrc/eeitt/model/EtmpBusinessUser.scala
@@ -1,9 +1,6 @@
 package uk.gov.hmrc.eeitt.model
 
 import play.api.libs.json._
-import uk.gov.hmrc.eeitt.services.LineParsingException
-
-//case class EtmpBusinessUser(registrationNumber: String, postcode: String)
 
 case class EtmpBusinessUser(
   registrationNumber: String,
@@ -23,81 +20,6 @@ object EtmpBusinessUser {
   implicit val format = Json.format[EtmpBusinessUser]
 }
 
-object Test {
-
-  val agent = "foo".split("") match {
-    case Array(
-      agentReferenceNumber,
-      agentIdentificationType,
-      agentIdentificationTypeDescription,
-      agentOrganisationType,
-      agentOrganisationTypeDescription,
-      agentOrganisationName,
-      agentTitle,
-      agentName1,
-      agentName2,
-      agentPostcode,
-      agentCountryCode,
-      customerIdentificationNumber,
-      customerTaxRegime,
-      customerTaxRegimeDescription,
-      customerOrganisationType,
-      customerOrganisationTypeDescription,
-      customerOrganisationName,
-      customerCustomerTitle,
-      customerCustomerName1,
-      customerCustomerName2,
-      customerPostcode,
-      customerCountryCode
-      ) =>
-      EtmpAgentRecord(
-        mandatory(agentReferenceNumber),
-        agentIdentificationType,
-        agentIdentificationTypeDescription,
-        agentOrganisationType,
-        agentOrganisationTypeDescription,
-        optional(agentOrganisationName),
-        optional(agentTitle),
-        optional(agentName1),
-        optional(agentName2),
-        optional(agentPostcode),
-        mandatory(agentCountryCode),
-        customer = EtmpBusinessUser(
-          mandatory(customerIdentificationNumber),
-          customerTaxRegime,
-          customerTaxRegimeDescription,
-          customerOrganisationType,
-          customerOrganisationTypeDescription,
-          optional(customerOrganisationName),
-          optional(customerCustomerTitle),
-          optional(customerCustomerName1),
-          optional(customerCustomerName2),
-          optional(customerPostcode),
-          mandatory(customerCountryCode)
-        )
-      )
-  }
-
-  def optional(s: String) = if (s.isEmpty) None else Some(s)
-  def mandatory(s: String) = if (s.nonEmpty) s else throw LineParsingException(s)
-
-}
-
-case class EtmpAgentRecord(
-  arn: String,
-  identificationType: String,
-  identificationTypeDescription: String,
-  organisationType: String,
-  organisationTypeDescription: String,
-  organisationName: Option[String],
-  title: Option[String],
-  name1: Option[String],
-  name2: Option[String],
-  postcode: Option[String],
-  countryCode: String,
-  customer: EtmpBusinessUser
-)
-
 case class EtmpAgent(
   arn: String,
   identificationType: String,
@@ -114,27 +36,6 @@ case class EtmpAgent(
 )
 
 object EtmpAgent {
-  def fromRecords(agentRecords: Seq[EtmpAgentRecord]): Seq[EtmpAgent] = {
-    agentRecords.groupBy(_.arn).map {
-      case (agentArn, records) =>
-        val agentData = records.head
-        import agentData._
-        EtmpAgent(
-          arn,
-          identificationType,
-          identificationTypeDescription,
-          organisationType,
-          organisationTypeDescription,
-          organisationName,
-          title,
-          name1,
-          name2,
-          postcode,
-          countryCode,
-          customers = records.map(_.customer)
-        )
-    }
-  }.toList
   implicit val format = Json.format[EtmpAgent]
 }
 

--- a/app/uk/gov/hmrc/eeitt/model/EtmpBusinessUser.scala
+++ b/app/uk/gov/hmrc/eeitt/model/EtmpBusinessUser.scala
@@ -1,16 +1,140 @@
 package uk.gov.hmrc.eeitt.model
 
 import play.api.libs.json._
+import uk.gov.hmrc.eeitt.services.LineParsingException
 
-case class EtmpBusinessUser(registrationNumber: String, postcode: String)
+//case class EtmpBusinessUser(registrationNumber: String, postcode: String)
+
+case class EtmpBusinessUser(
+  registrationNumber: String,
+  taxRegime: String,
+  taxRegimeDescription: String,
+  organisationType: String,
+  organisationTypeDescription: String,
+  organisationName: Option[String],
+  customerTitle: Option[String],
+  customerName1: Option[String],
+  customerName2: Option[String],
+  postcode: Option[String],
+  countryCode: String
+)
 
 object EtmpBusinessUser {
   implicit val format = Json.format[EtmpBusinessUser]
 }
 
-case class EtmpAgent(arn: String)
+object Test {
+
+  val agent = "foo".split("") match {
+    case Array(
+      agentReferenceNumber,
+      agentIdentificationType,
+      agentIdentificationTypeDescription,
+      agentOrganisationType,
+      agentOrganisationTypeDescription,
+      agentOrganisationName,
+      agentTitle,
+      agentName1,
+      agentName2,
+      agentPostcode,
+      agentCountryCode,
+      customerIdentificationNumber,
+      customerTaxRegime,
+      customerTaxRegimeDescription,
+      customerOrganisationType,
+      customerOrganisationTypeDescription,
+      customerOrganisationName,
+      customerCustomerTitle,
+      customerCustomerName1,
+      customerCustomerName2,
+      customerPostcode,
+      customerCountryCode
+      ) =>
+      EtmpAgentRecord(
+        mandatory(agentReferenceNumber),
+        agentIdentificationType,
+        agentIdentificationTypeDescription,
+        agentOrganisationType,
+        agentOrganisationTypeDescription,
+        optional(agentOrganisationName),
+        optional(agentTitle),
+        optional(agentName1),
+        optional(agentName2),
+        optional(agentPostcode),
+        mandatory(agentCountryCode),
+        customer = EtmpBusinessUser(
+          mandatory(customerIdentificationNumber),
+          customerTaxRegime,
+          customerTaxRegimeDescription,
+          customerOrganisationType,
+          customerOrganisationTypeDescription,
+          optional(customerOrganisationName),
+          optional(customerCustomerTitle),
+          optional(customerCustomerName1),
+          optional(customerCustomerName2),
+          optional(customerPostcode),
+          mandatory(customerCountryCode)
+        )
+      )
+  }
+
+  def optional(s: String) = if (s.isEmpty) None else Some(s)
+  def mandatory(s: String) = if (s.nonEmpty) s else throw LineParsingException(s)
+
+}
+
+case class EtmpAgentRecord(
+  arn: String,
+  identificationType: String,
+  identificationTypeDescription: String,
+  organisationType: String,
+  organisationTypeDescription: String,
+  organisationName: Option[String],
+  title: Option[String],
+  name1: Option[String],
+  name2: Option[String],
+  postcode: Option[String],
+  countryCode: String,
+  customer: EtmpBusinessUser
+)
+
+case class EtmpAgent(
+  arn: String,
+  identificationType: String,
+  identificationTypeDescription: String,
+  organisationType: String,
+  organisationTypeDescription: String,
+  organisationName: Option[String],
+  title: Option[String],
+  name1: Option[String],
+  name2: Option[String],
+  postcode: Option[String],
+  countryCode: String,
+  customers: Seq[EtmpBusinessUser]
+)
 
 object EtmpAgent {
+  def fromRecords(agentRecords: Seq[EtmpAgentRecord]): Seq[EtmpAgent] = {
+    agentRecords.groupBy(_.arn).map {
+      case (agentArn, records) =>
+        val agentData = records.head
+        import agentData._
+        EtmpAgent(
+          arn,
+          identificationType,
+          identificationTypeDescription,
+          organisationType,
+          organisationTypeDescription,
+          organisationName,
+          title,
+          name1,
+          name2,
+          postcode,
+          countryCode,
+          customers = records.map(_.customer)
+        )
+    }
+  }.toList
   implicit val format = Json.format[EtmpAgent]
 }
 

--- a/app/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepository.scala
+++ b/app/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepository.scala
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait EtmpAgentRepository {
-  def agentExists(etmpAgent: EtmpAgent): Future[Boolean]
+  def agentExists(arn: String): Future[Boolean]
 
   def replaceAll(users: Seq[EtmpAgent]): Future[MultiBulkWriteResult]
 }
@@ -31,9 +31,9 @@ class MongoEtmpAgentRepository(implicit mongo: () => DB)
     ).map(Seq(_))
   }
 
-  def agentExists(etmpAgent: EtmpAgent): Future[Boolean] = {
+  def agentExists(arn: String): Future[Boolean] = {
     collection
-      .find(etmpAgent)
+      .find(Json.obj("arn" -> arn))
       .cursor[EtmpAgent](ReadPreference.secondaryPreferred)
       .collect[List]()
       .map(_.nonEmpty)

--- a/app/uk/gov/hmrc/eeitt/services/EtmpDataParser.scala
+++ b/app/uk/gov/hmrc/eeitt/services/EtmpDataParser.scala
@@ -148,7 +148,7 @@ object EtmpDataParser {
 
   // This represents a single agent line as provided by ETMP. There will be as many lines for each agent
   // as many clients they have. This class is only used internally when parsing the file and all
-  // further interactions are done with EtmpAgent class which represents and agent and all their customers
+  // further interactions are done with EtmpAgent class which represents an agent and all their customers
   // in one class
   private[services] case class EtmpAgentRecord(
     arn: String,

--- a/app/uk/gov/hmrc/eeitt/services/EtmpDataParser.scala
+++ b/app/uk/gov/hmrc/eeitt/services/EtmpDataParser.scala
@@ -1,31 +1,133 @@
 package uk.gov.hmrc.eeitt.services
 
-import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpAgentRecord, EtmpBusinessUser }
+import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpBusinessUser }
 
-/*
-    todo: add more constraints once we know more about the data:
-    - optionality of fields?
-    - expected number of chars?
-    - non-empty values?
-    - validate postcode?
-    - use ScalaCheck to test all that?
- */
-trait EtmpDataParser[A] {
-  // escaped because literal | has meaning in regex
-  def delimiter = "\\|"
+object EtmpDataParser {
 
-  def isRecord(line: String): Boolean
+  def parseFileWithBusinessUsers(source: String): List[EtmpBusinessUser] = {
+    source.lines
+      .filter(isUserRecord)
+      .map(parseBusinessUserLine)
+      .toList
+  }
+
+  def parseBusinessUserLine(line: String): EtmpBusinessUser = {
+    line.split(escapedDelimiter) match {
+      case Array(
+        fileType,
+        registrationNumber,
+        customerTaxRegime,
+        customerTaxRegimeDescription,
+        customerOrganisationType,
+        customerOrganisationTypeDescription,
+        customerOrganisationName,
+        customerTitle,
+        customerName1,
+        customerName2,
+        postcode,
+        countryCode
+        ) => {
+        val mandatory = mandatoryValue(line) _
+        EtmpBusinessUser(
+          mandatory("registrationNumber", registrationNumber),
+          customerTaxRegime,
+          customerTaxRegimeDescription,
+          customerOrganisationType,
+          customerOrganisationTypeDescription,
+          optional(customerOrganisationName),
+          optional(customerTitle),
+          optional(customerName1),
+          optional(customerName2),
+          mandatoryPostcodeIfFromTheUk(line, countryCode, postcode),
+          mandatory("countryCode", countryCode)
+        )
+      }
+      case _ => throw unexpectedNumberOfTokensException(line)
+    }
+  }
+
+  def parseFileWithAgents(source: String): List[EtmpAgent] = {
+    val agentRecords = source.lines
+      .filter(isAgentRecord)
+      .map(parseAgentLine).toList
+    agentsFromAgentRecords(agentRecords)
+  }
+
+  def parseAgentLine(line: String): EtmpAgentRecord = {
+    val tokens = line.split(escapedDelimiter)
+    val expectedNumberOfTokens = 23 // 23 > the unfortunate scala limit of 22 so had to make it more complex...
+    val expectedPositionOfUser = 12
+    if (tokens.size == expectedNumberOfTokens) {
+      tokens.splitAt(expectedPositionOfUser) match {
+        case (agent @ Array(
+          fileType,
+          arn,
+          agentIdentificationType,
+          agentIdentificationTypeDescription,
+          agentOrganisationType,
+          agentOrganisationTypeDescription,
+          agentOrganisationName,
+          agentTitle,
+          agentName1,
+          agentName2,
+          agentPostcode,
+          agentCountryCode
+          ), userTokens: Tokens) => {
+          val mandatory = mandatoryValue(line) _
+          EtmpAgentRecord(
+            mandatory("arn", arn),
+            agentIdentificationType,
+            agentIdentificationTypeDescription,
+            agentOrganisationType,
+            agentOrganisationTypeDescription,
+            optional(agentOrganisationName),
+            optional(agentTitle),
+            optional(agentName1),
+            optional(agentName2),
+            mandatoryPostcodeIfFromTheUk(line, agentCountryCode, agentPostcode),
+            mandatory("agentCountryCode", agentCountryCode),
+            customer = parseBusinessUserLine {
+              // reusing customer parser but had to add a file type prefix which it expects
+              val customerPartOfTheAgentLine = ("fileTypePrefix" +: userTokens).mkString(delimiter)
+              customerPartOfTheAgentLine
+            }
+          )
+        }
+      }
+    } else {
+      throw unexpectedNumberOfTokensException(line)
+    }
+  }
+
+  def agentsFromAgentRecords(agentRecords: List[EtmpAgentRecord]): List[EtmpAgent] =
+    agentRecords.groupBy(_.arn).map {
+      case (agentArn, records) =>
+        val agentData = records.head
+        import agentData._
+        EtmpAgent(
+          arn,
+          identificationType,
+          identificationTypeDescription,
+          organisationType,
+          organisationTypeDescription,
+          organisationName,
+          title,
+          name1,
+          name2,
+          postcode,
+          countryCode,
+          customers = records.map(_.customer)
+        )
+    }.toList
+
+  val delimiter = "|"
+  val escapedDelimiter = """\""" + delimiter // escaped because pipe symbol has meaning in regex which is used by the split method
+
+  def isUserRecord(line: String): Boolean = line.startsWith("001|")
+
+  def isAgentRecord(line: String): Boolean = line.startsWith("002|")
 
   type Tokens = Array[String]
-
-  def extractDataFromTokens(line: String): PartialFunction[Tokens, A]
-
-  def parseLine(line: String): A = {
-    extractDataFromTokens(line).applyOrElse(
-      line.split(delimiter),
-      (_: Tokens) => throw LineParsingException(s"Failed to parse due to unexpected format of line: $line")
-    )
-  }
 
   def optional(s: String) = if (s.isEmpty) None else Some(s)
 
@@ -33,7 +135,7 @@ trait EtmpDataParser[A] {
     if (fieldValue.trim.nonEmpty) fieldValue else throw LineParsingException(s"Missing $fieldName in line: $line")
   }
 
-  def mandatoryPostcodeIfFromGB(line: String, countryCode: String, postcode: String): Option[String] = {
+  def mandatoryPostcodeIfFromTheUk(line: String, countryCode: String, postcode: String): Option[String] = {
     if (countryCode == "GB" && postcode.trim.isEmpty) {
       throw LineParsingException(s"Missing postcode for a UK entity in line: $line")
     } else {
@@ -41,147 +143,29 @@ trait EtmpDataParser[A] {
     }
   }
 
-  def parseFile(source: String): List[A] = {
-    source.lines
-      .filter(isRecord)
-      .map(parseLine)
-      .toList
-  }
+  def unexpectedNumberOfTokensException(line: String) =
+    LineParsingException(s"Failed to parse due to unexpected format of line: $line")
+
+  // This represents a single agent line as provided by ETMP. There will be as many lines for each agent
+  // as many clients they have. This class is only used internally when parsing the file and all
+  // further interactions are done with EtmpAgent class which represents and agent and all their customers
+  // in one class
+  private[services] case class EtmpAgentRecord(
+    arn: String,
+    identificationType: String,
+    identificationTypeDescription: String,
+    organisationType: String,
+    organisationTypeDescription: String,
+    organisationName: Option[String],
+    title: Option[String],
+    name1: Option[String],
+    name2: Option[String],
+    postcode: Option[String],
+    countryCode: String,
+    customer: EtmpBusinessUser
+  )
+
 }
 
 case class LineParsingException(msg: String) extends Exception(msg)
-
-/*
- *  Imported File from ETMP has following structure for Business Users:
- *  - header line: 00|CUSTOMER_DATA|ETMP|MDTP|DATE_OF_EXPORT|TIME_OF_EXPORT
- *  - records with a structure like: 001|XTAL00000100044|ZAGL|Aggregate Levy (AGL)|7|Limited Company|Organisation1||||BN12 4XL|GB
- *    where tokens delimited by the pipe | character are as follows:
- *      - File Type
- *      - Customer Identification Number (aka registration number)
- *      - Customer Tax regime
- *      - Customer Organisation Type
- *      - Customer Organisation Type Description
- *      - Customer Organisation Name
- *      - Customer Title
- *      - Customer Name1
- *      - Customer Name2
- *      - Customer Postal Code
- *      - Customer Country Code
- *  - EOF line: 99|CUSTOMER_DATA|NUMBER_OF_RECORDS
- */
-object EtmpBusinessUserParser extends EtmpDataParser[EtmpBusinessUser] {
-  def extractDataFromTokens(line: String) = {
-    case Array(
-      fileType,
-      registrationNumber,
-      customerTaxRegime,
-      customerTaxRegimeDescription,
-      customerOrganisationType,
-      customerOrganisationTypeDescription,
-      customerOrganisationName,
-      customerTitle,
-      customerName1,
-      customerName2,
-      postcode,
-      countryCode
-      ) => {
-      val mandatory = mandatoryValue(line) _
-      EtmpBusinessUser(
-        mandatory("registrationNumber", registrationNumber),
-        customerTaxRegime,
-        customerTaxRegimeDescription,
-        customerOrganisationType,
-        customerOrganisationTypeDescription,
-        optional(customerOrganisationName),
-        optional(customerTitle),
-        optional(customerName1),
-        optional(customerName2),
-        mandatoryPostcodeIfFromGB(line, countryCode, postcode),
-        mandatory("countryCode", countryCode)
-      )
-    }
-  }
-
-  def isRecord(line: String): Boolean = line.startsWith("001|")
-}
-
-/*
- *  Imported File from ETMP has following structure for Agents:
- *  - header line: 00|AGENT_DATA|ETMP|MDTP|DATE_OF_EXPORT|TIME_OF_EXPORT
- *  - records with following structure: 002|KARN0000086|ARN|Agent1||||BN12 4XL|XMAP00000100051|ZAPD|Organisation1|||
- *    where tokens are as follows:
- *      - File Type
- *      - Agent Reference Number
- *      - Agent Reference Type
- *      - Agent Organisation Name
- *      - Agent Title
- *      - Agent Name1
- *      - Agent Name2
- *      - Agent Postal Code
- *      - Customer Reference Number
- *      - Customer Tax regime
- *      - Customer Organisation Name
- *      - Customer Title
- *      - Customer Name1
- *      - Customer Name2
- *  - EOF line: 99|AGENT_DATA|NUMBER_OF_RECORDS
- */
-object EtmpAgentRecordParser extends EtmpDataParser[EtmpAgentRecord] {
-  def extractDataFromTokens(line: String) = {
-    case Array(
-      arn,
-      agentIdentificationType,
-      agentIdentificationTypeDescription,
-      agentOrganisationType,
-      agentOrganisationTypeDescription,
-      agentOrganisationName,
-      agentTitle,
-      agentName1,
-      agentName2,
-      agentPostcode,
-      agentCountryCode,
-      customerIdentificationNumber,
-      customerTaxRegime,
-      customerTaxRegimeDescription,
-      customerOrganisationType,
-      customerOrganisationTypeDescription,
-      customerOrganisationName,
-      customerCustomerTitle,
-      customerCustomerName1,
-      customerCustomerName2,
-      customerPostcode,
-      customerCountryCode
-      ) => {
-      val mandatory = mandatoryValue(line) _
-      EtmpAgentRecord(
-        mandatory("arn", arn),
-        agentIdentificationType,
-        agentIdentificationTypeDescription,
-        agentOrganisationType,
-        agentOrganisationTypeDescription,
-        optional(agentOrganisationName),
-        optional(agentTitle),
-        optional(agentName1),
-        optional(agentName2),
-        mandatoryPostcodeIfFromGB(line, agentCountryCode, agentPostcode),
-        mandatory("agentCountryCode", agentCountryCode),
-        customer = EtmpBusinessUser(
-          mandatory("customerIdentificationNumber", customerIdentificationNumber),
-          customerTaxRegime,
-          customerTaxRegimeDescription,
-          customerOrganisationType,
-          customerOrganisationTypeDescription,
-          optional(customerOrganisationName),
-          optional(customerCustomerTitle),
-          optional(customerCustomerName1),
-          optional(customerCustomerName2),
-          mandatoryPostcodeIfFromGB(line, customerPostcode, customerCountryCode),
-          mandatory("customerCountryCode", customerCountryCode)
-        )
-      )
-    }
-  }
-
-  def isRecord(line: String): Boolean = line.startsWith("002|")
-}
 

--- a/app/uk/gov/hmrc/eeitt/services/EtmpDataParser.scala
+++ b/app/uk/gov/hmrc/eeitt/services/EtmpDataParser.scala
@@ -1,6 +1,6 @@
 package uk.gov.hmrc.eeitt.services
 
-import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpBusinessUser }
+import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpAgentRecord, EtmpBusinessUser }
 
 /*
     todo: add more constraints once we know more about the data:
@@ -18,13 +18,27 @@ trait EtmpDataParser[A] {
 
   type Tokens = Array[String]
 
-  def extractDataFromTokens: PartialFunction[Tokens, A]
+  def extractDataFromTokens(line: String): PartialFunction[Tokens, A]
 
   def parseLine(line: String): A = {
-    extractDataFromTokens.applyOrElse(
+    extractDataFromTokens(line).applyOrElse(
       line.split(delimiter),
-      (_: Tokens) => throw LineParsingException(s"Failed to parse due to unexpected format of the line: $line")
+      (_: Tokens) => throw LineParsingException(s"Failed to parse due to unexpected format of line: $line")
     )
+  }
+
+  def optional(s: String) = if (s.isEmpty) None else Some(s)
+
+  def mandatoryValue(line: String)(fieldName: String, fieldValue: String) = {
+    if (fieldValue.trim.nonEmpty) fieldValue else throw LineParsingException(s"Missing $fieldName in line: $line")
+  }
+
+  def mandatoryPostcodeIfFromGB(line: String, countryCode: String, postcode: String): Option[String] = {
+    if (countryCode == "GB" && postcode.trim.isEmpty) {
+      throw LineParsingException(s"Missing postcode for a UK entity in line: $line")
+    } else {
+      optional(postcode)
+    }
   }
 
   def parseFile(source: String): List[A] = {
@@ -40,22 +54,52 @@ case class LineParsingException(msg: String) extends Exception(msg)
 /*
  *  Imported File from ETMP has following structure for Business Users:
  *  - header line: 00|CUSTOMER_DATA|ETMP|MDTP|DATE_OF_EXPORT|TIME_OF_EXPORT
- *  - records with following structure: 001|XTAL00000100044|ZAGL|Organisation1||||BN12 4XL
- *    where tokens are as follows:
+ *  - records with a structure like: 001|XTAL00000100044|ZAGL|Aggregate Levy (AGL)|7|Limited Company|Organisation1||||BN12 4XL|GB
+ *    where tokens delimited by the pipe | character are as follows:
  *      - File Type
- *      - Customer Reference Number
+ *      - Customer Identification Number (aka registration number)
  *      - Customer Tax regime
+ *      - Customer Organisation Type
+ *      - Customer Organisation Type Description
  *      - Customer Organisation Name
  *      - Customer Title
  *      - Customer Name1
  *      - Customer Name2
  *      - Customer Postal Code
+ *      - Customer Country Code
  *  - EOF line: 99|CUSTOMER_DATA|NUMBER_OF_RECORDS
  */
 object EtmpBusinessUserParser extends EtmpDataParser[EtmpBusinessUser] {
-  def extractDataFromTokens = {
-    case Array(_, regNum, _, _, _, _, _, postcode) if regNum.nonEmpty && postcode.nonEmpty =>
-      EtmpBusinessUser(regNum, postcode)
+  def extractDataFromTokens(line: String) = {
+    case Array(
+      fileType,
+      registrationNumber,
+      customerTaxRegime,
+      customerTaxRegimeDescription,
+      customerOrganisationType,
+      customerOrganisationTypeDescription,
+      customerOrganisationName,
+      customerTitle,
+      customerName1,
+      customerName2,
+      postcode,
+      countryCode
+      ) => {
+      val mandatory = mandatoryValue(line) _
+      EtmpBusinessUser(
+        mandatory("registrationNumber", registrationNumber),
+        customerTaxRegime,
+        customerTaxRegimeDescription,
+        customerOrganisationType,
+        customerOrganisationTypeDescription,
+        optional(customerOrganisationName),
+        optional(customerTitle),
+        optional(customerName1),
+        optional(customerName2),
+        mandatoryPostcodeIfFromGB(line, countryCode, postcode),
+        mandatory("countryCode", countryCode)
+      )
+    }
   }
 
   def isRecord(line: String): Boolean = line.startsWith("001|")
@@ -82,9 +126,60 @@ object EtmpBusinessUserParser extends EtmpDataParser[EtmpBusinessUser] {
  *      - Customer Name2
  *  - EOF line: 99|AGENT_DATA|NUMBER_OF_RECORDS
  */
-object EtmpAgentParser extends EtmpDataParser[EtmpAgent] {
-  def extractDataFromTokens = {
-    case Array(_, arn, _*) if arn.nonEmpty => EtmpAgent(arn)
+object EtmpAgentRecordParser extends EtmpDataParser[EtmpAgentRecord] {
+  def extractDataFromTokens(line: String) = {
+    case Array(
+      arn,
+      agentIdentificationType,
+      agentIdentificationTypeDescription,
+      agentOrganisationType,
+      agentOrganisationTypeDescription,
+      agentOrganisationName,
+      agentTitle,
+      agentName1,
+      agentName2,
+      agentPostcode,
+      agentCountryCode,
+      customerIdentificationNumber,
+      customerTaxRegime,
+      customerTaxRegimeDescription,
+      customerOrganisationType,
+      customerOrganisationTypeDescription,
+      customerOrganisationName,
+      customerCustomerTitle,
+      customerCustomerName1,
+      customerCustomerName2,
+      customerPostcode,
+      customerCountryCode
+      ) => {
+      val mandatory = mandatoryValue(line) _
+      EtmpAgentRecord(
+        mandatory("arn", arn),
+        agentIdentificationType,
+        agentIdentificationTypeDescription,
+        agentOrganisationType,
+        agentOrganisationTypeDescription,
+        optional(agentOrganisationName),
+        optional(agentTitle),
+        optional(agentName1),
+        optional(agentName2),
+        mandatoryPostcodeIfFromGB(line, agentCountryCode, agentPostcode),
+        mandatory("agentCountryCode", agentCountryCode),
+        customer = EtmpBusinessUser(
+          mandatory("customerIdentificationNumber", customerIdentificationNumber),
+          customerTaxRegime,
+          customerTaxRegimeDescription,
+          customerOrganisationType,
+          customerOrganisationTypeDescription,
+          optional(customerOrganisationName),
+          optional(customerCustomerTitle),
+          optional(customerCustomerName1),
+          optional(customerCustomerName2),
+          mandatoryPostcodeIfFromGB(line, customerPostcode, customerCountryCode),
+          mandatory("customerCountryCode", customerCountryCode)
+        )
+      )
+    }
   }
 
   def isRecord(line: String): Boolean = line.startsWith("002|")

--- a/app/uk/gov/hmrc/eeitt/services/RegistrationService.scala
+++ b/app/uk/gov/hmrc/eeitt/services/RegistrationService.scala
@@ -16,7 +16,7 @@ trait RegistrationService {
   def agentRepository: EtmpAgentRepository
 
   def register(registerRequest: RegisterRequest): Future[RegistrationResponse] = {
-    userRepository.userExists(EtmpBusinessUser(registerRequest.registrationNumber, registerRequest.postcode)).flatMap {
+    userRepository.userExists(registerRequest.registrationNumber, registerRequest.postcode).flatMap {
       case true =>
         regRepository.findRegistrations(registerRequest.groupId).flatMap {
           case Nil => addRegistration(registerRequest)
@@ -33,7 +33,7 @@ trait RegistrationService {
   }
 
   def register(registerAgentRequest: RegisterAgentRequest): Future[RegistrationResponse] = {
-    agentRepository.agentExists(EtmpAgent(registerAgentRequest.arn)).flatMap {
+    agentRepository.agentExists(registerAgentRequest.arn).flatMap {
       case true =>
         regRepository.findRegistrations(registerAgentRequest.groupId).flatMap {
           case Nil => addRegistration(registerAgentRequest)

--- a/app/uk/gov/hmrc/eeitt/utils/NonFatalWithLogging.scala
+++ b/app/uk/gov/hmrc/eeitt/utils/NonFatalWithLogging.scala
@@ -1,0 +1,15 @@
+package uk.gov.hmrc.eeitt.utils
+
+import play.api.Logger
+
+import scala.util.control.NonFatal
+
+object NonFatalWithLogging {
+  def unapply(t: Throwable) = {
+    val result = NonFatal.unapply(t)
+    result.foreach { _ =>
+      Logger.debug(t.getMessage, t)
+    }
+    result
+  }
+}

--- a/test/uk/gov/hmrc/eeitt/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/controllers/RegistrationControllerSpec.scala
@@ -27,11 +27,11 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
     )))
     regRepository.findRegistrations("5").returns(Future.successful(List(Registration("5", true, "", "KARN001", List()))))
     val userRepository = mock[MongoEtmpBusinessUsersRepository]
-    userRepository.userExists(EtmpBusinessUser("12LT001", "SE39EP")).returns(Future.successful(true))
-    userRepository.userExists(EtmpBusinessUser("12LT009", "SE39EPX")).returns(Future.successful(false))
+    userRepository.userExists("12LT001", "SE39EP").returns(Future.successful(true))
+    userRepository.userExists("12LT009", "SE39EPX").returns(Future.successful(false))
     val agentRepository = mock[MongoEtmpAgentRepository]
-    agentRepository.agentExists(EtmpAgent("KARN001")).returns(Future.successful(true))
-    agentRepository.agentExists(EtmpAgent("KARN002")).returns(Future.successful(false))
+    agentRepository.agentExists("KARN001").returns(Future.successful(true))
+    agentRepository.agentExists("KARN002").returns(Future.successful(false))
   }
 
   object TestRegistrationController extends RegistrationController {

--- a/test/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepositorySpec.scala
@@ -1,7 +1,5 @@
 package uk.gov.hmrc.eeitt.repositories
 
-import java.util.UUID
-
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.eeitt.model.EtmpAgent
@@ -9,6 +7,7 @@ import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Random
 
 class EtmpAgentRepositorySpec extends UnitSpec with MongoSpecSupport with BeforeAndAfterEach with ScalaFutures {
 
@@ -16,13 +15,13 @@ class EtmpAgentRepositorySpec extends UnitSpec with MongoSpecSupport with Before
     "return `true` if at least one agent existed" in {
       insert(EtmpAgent(arn = "arn"))
 
-      repo.agentExists(EtmpAgent(arn = "arn")).futureValue shouldBe true
+      repo.agentExists("arn").futureValue shouldBe true
     }
     "return `false` otherwise" in {
       insert(EtmpAgent(arn = "otherArn"))
-      val agentToLookUp = EtmpAgent(arn = "arn")
+      val arnToLookup = "arn"
 
-      repo.agentExists(agentToLookUp).futureValue shouldBe false
+      repo.agentExists(arnToLookup).futureValue shouldBe false
     }
   }
 
@@ -54,9 +53,22 @@ class EtmpAgentRepositorySpec extends UnitSpec with MongoSpecSupport with Before
   def insert(EtmpAgent: EtmpAgent) = await(repo.collection.insert(EtmpAgent))
 
   def testEtmpAgent() = {
-    def randomize(s: String) = s + "-" + UUID.randomUUID()
+    def randomize(s: String) = s + "-" + Random.alphanumeric.take(10).mkString
 
-    EtmpAgent(randomize("arn"))
+    EtmpAgent(
+      randomize("arn"),
+      randomize("identificationType"),
+      randomize("identificationTypeDescription"),
+      randomize("organisationType"),
+      randomize("organisationTypeDescription"),
+      randomize("organisationName"),
+      randomize("title"),
+      randomize("name1"),
+      randomize("name2"),
+      randomize("postcode"),
+      randomize("countryCode"),
+      customers = records.map(_.customer)
+    )
   }
 
 }

--- a/test/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepositorySpec.scala
@@ -13,13 +13,13 @@ class EtmpAgentRepositorySpec extends UnitSpec with MongoSpecSupport with Before
 
   "Checking if agent exists in the db" should {
     "return `true` if at least one agent existed" in {
-      insert(EtmpAgent(arn = "arn"))
+      insert(testEtmpAgent().copy(arn = "arn"))
 
       repo.agentExists("arn").futureValue shouldBe true
     }
     "return `false` otherwise" in {
-      insert(EtmpAgent(arn = "otherArn"))
       val arnToLookup = "arn"
+      insert(testEtmpAgent().copy(arn = "otherArn"))
 
       repo.agentExists(arnToLookup).futureValue shouldBe false
     }
@@ -54,20 +54,19 @@ class EtmpAgentRepositorySpec extends UnitSpec with MongoSpecSupport with Before
 
   def testEtmpAgent() = {
     def randomize(s: String) = s + "-" + Random.alphanumeric.take(10).mkString
-
     EtmpAgent(
       randomize("arn"),
       randomize("identificationType"),
       randomize("identificationTypeDescription"),
       randomize("organisationType"),
       randomize("organisationTypeDescription"),
-      randomize("organisationName"),
-      randomize("title"),
-      randomize("name1"),
-      randomize("name2"),
-      randomize("postcode"),
+      Some(randomize("organisationName")),
+      Some(randomize("title")),
+      Some(randomize("name1")),
+      Some(randomize("name2")),
+      Some(randomize("postcode")),
       randomize("countryCode"),
-      customers = records.map(_.customer)
+      customers = Seq()
     )
   }
 

--- a/test/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepositorySupport.scala
+++ b/test/uk/gov/hmrc/eeitt/repositories/EtmpAgentRepositorySupport.scala
@@ -12,8 +12,7 @@ trait EtmpAgentRepositorySupport extends UnitSpec with MongoSpecSupport {
   val agentRepo = new MongoEtmpAgentRepository
 
   def insertAgent(etmpBusinessUser: EtmpAgent): Unit = {
-    val g = EtmpAgent(etmpBusinessUser.arn)
-    await(agentRepo.collection.insert(g))
+    await(agentRepo.collection.insert(etmpBusinessUser))
   }
 
   def awaitAgentIndexCreation() = {

--- a/test/uk/gov/hmrc/eeitt/repositories/EtmpBusinessUserRepositorySupport.scala
+++ b/test/uk/gov/hmrc/eeitt/repositories/EtmpBusinessUserRepositorySupport.scala
@@ -12,8 +12,7 @@ trait EtmpBusinessUserRepositorySupport extends UnitSpec with MongoSpecSupport {
   val userRepo = new MongoEtmpBusinessUsersRepository
 
   def insertBusinessUser(etmpBusinessUser: EtmpBusinessUser): Unit = {
-    val g = EtmpBusinessUser(etmpBusinessUser.registrationNumber, etmpBusinessUser.postcode)
-    await(userRepo.collection.insert(g))
+    await(userRepo.collection.insert(etmpBusinessUser))
   }
 
   def awaitUserIndexCreation() = {

--- a/test/uk/gov/hmrc/eeitt/services/EtmpDataParserSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/services/EtmpDataParserSpec.scala
@@ -4,10 +4,13 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class EtmpDataParserSpec extends UnitSpec {
 
+  // Specification of ETMP files can be found here: https://confluence.tools.tax.service.gov.uk/display/AF/ETMP+data
+  // there are more rules that are tested here but they relate to fields we don't really care about for now
+
   "Parsing individual lines of a flat file containing ETMP business users" should {
     "succeed if line matches expected format" in {
       val validLine = "001|regNum|taxReg|taxRegDesc|orgType|orgTypeDesc|orgName|title|name1|name2|postcode|countryCode"
-      noException should be thrownBy EtmpBusinessUserParser.parseLine(validLine)
+      noException should be thrownBy EtmpDataParser.parseBusinessUserLine(validLine)
     }
 
     "fail if registration number (aka customer identification number) is missing" in {
@@ -17,7 +20,7 @@ class EtmpDataParserSpec extends UnitSpec {
       )
 
       missingOrEmptyRegNumber.foreach { line =>
-        val exception = intercept[LineParsingException] { EtmpBusinessUserParser.parseLine(line) }
+        val exception = intercept[LineParsingException] { EtmpDataParser.parseBusinessUserLine(line) }
         exception.msg shouldBe s"Missing registrationNumber in line: $line"
       }
     }
@@ -29,7 +32,7 @@ class EtmpDataParserSpec extends UnitSpec {
       )
 
       missingOrEmptyPostcode.foreach { line =>
-        val exception = intercept[LineParsingException] { EtmpBusinessUserParser.parseLine(line) }
+        val exception = intercept[LineParsingException] { EtmpDataParser.parseBusinessUserLine(line) }
         exception.msg shouldBe s"Missing postcode for a UK entity in line: $line"
       }
     }
@@ -38,13 +41,11 @@ class EtmpDataParserSpec extends UnitSpec {
       val invalidLine = "foo|bar"
 
       val exception = intercept[LineParsingException] {
-        EtmpBusinessUserParser.parseLine(invalidLine)
+        EtmpDataParser.parseBusinessUserLine(invalidLine)
       }
 
       exception.msg shouldBe s"Failed to parse due to unexpected format of line: $invalidLine"
     }
-
-    // todo specification gives many additional rules for ETMP data set however we don't care for now
 
   }
 
@@ -64,14 +65,14 @@ class EtmpDataParserSpec extends UnitSpec {
           >
         """.stripMargin('>')
 
-      EtmpBusinessUserParser.parseFile(flatFile).size shouldBe 7
+      EtmpDataParser.parseFileWithBusinessUsers(flatFile).size shouldBe 7
     }
   }
 
   "Parsing individual lines of a flat file containing ETMP agents" should {
     "succeed if line matches expected format" in {
       val validLine = "fileType|arn|AgentIdType|AgentIdTypeDesc|AgentOrgType|AgentOrgTypeDesc|AgentOrgName|AgentTitle|AgentName1|AgentName2|AgentPostcode|AgentCountryCode|CustRegNum|CustTaxReg|CustTaxRegDesc|CustOrgType|CustOrgTypeDesc|CustOrgName|CustTitle|CustName1|CustName2|CustPostcode|CustCountryCode"
-      noException should be thrownBy EtmpAgentRecordParser.parseLine(validLine)
+      noException should be thrownBy EtmpDataParser.parseAgentLine(validLine)
     }
 
     "fail if Agent Reference Number (arn) is missing" in {
@@ -81,13 +82,35 @@ class EtmpDataParserSpec extends UnitSpec {
       )
 
       missingOrEmptyARN.foreach { line =>
-        val exception = intercept[LineParsingException] { EtmpAgentRecordParser.parseFile(line) }
+        val exception = intercept[LineParsingException] { EtmpDataParser.parseAgentLine(line) }
         exception.msg shouldBe s"Missing arn in line: $line"
       }
     }
+
+    "fail if agent is from the UK but doesn't have a postcode" in {
+      val missingOrEmptyPostcode = List(
+        "fileType|arn|AgentIdType|AgentIdTypeDesc|AgentOrgType|AgentOrgTypeDesc|AgentOrgName|AgentTitle|AgentName1|AgentName2|       |GB|CustRegNum|CustTaxReg|CustTaxRegDesc|CustOrgType|CustOrgTypeDesc|CustOrgName|CustTitle|CustName1|CustName2|CustPostcode|CustCountryCode",
+        "fileType|arn|AgentIdType|AgentIdTypeDesc|AgentOrgType|AgentOrgTypeDesc|AgentOrgName|AgentTitle|AgentName1|AgentName2||GB|CustRegNum|CustTaxReg|CustTaxRegDesc|CustOrgType|CustOrgTypeDesc|CustOrgName|CustTitle|CustName1|CustName2|CustPostcode|CustCountryCode"
+      )
+
+      missingOrEmptyPostcode.foreach { line =>
+        val exception = intercept[LineParsingException] { EtmpDataParser.parseAgentLine(line) }
+        exception.msg shouldBe s"Missing postcode for a UK entity in line: $line"
+      }
+    }
+
+    "fail if customer part of an agent record is invalid" in {
+      val missingRegNum = "fileType|arn|AgentIdType|AgentIdTypeDesc|AgentOrgType|AgentOrgTypeDesc|AgentOrgName|AgentTitle|AgentName1|AgentName2|AgentPostcode|AgentCountryCode||CustTaxReg|CustTaxRegDesc|CustOrgType|CustOrgTypeDesc|CustOrgName|CustTitle|CustName1|CustName2|CustPostcode|CustCountryCode"
+      val exception = intercept[LineParsingException] { EtmpDataParser.parseAgentLine(missingRegNum) }
+      exception.msg should include("Missing registrationNumber")
+      // other problems with a customer part of the record are assumed to also be captured as we re-use a function
+      // that is unit tested above
+    }
+
     "fail if line contains incorrect number of tokens" in {
       val invalidLine = "not|enough|tokens"
-      a[LineParsingException] should be thrownBy EtmpAgentRecordParser.parseLine(invalidLine)
+      val exception = intercept[LineParsingException] { EtmpDataParser.parseAgentLine(invalidLine) }
+      exception.msg should include(s"Failed to parse due to unexpected format of line: $invalidLine")
     }
   }
 
@@ -96,18 +119,20 @@ class EtmpDataParserSpec extends UnitSpec {
       val flatFile =
         """
           >00|AGENT_DATA|ETMP|MDTP|20161103|141316
-          >002|KARN0000086|ARN|Agent1||||BN12 4XL|XMAP00000100051|ZAPD|Organisation1|||
-          >002|KARN0000086|ARN|Agent1||||BN12 4XL|XRIP00000100053|ZIPT||Mr|Name11|Name21
-          >002|KARN0000086|ARN|Agent1||||BN12 4XL|XSBD00440000020|ZBD|Organisation3|||
-          >002|KARN0000087|ARN|Agent2||||BN12 4XL|XTAL00000100044|ZAGL|Organisation1|||
-          >002|KARN0000087|ARN|Agent2||||BN12 4XL|XRIP00000100053|ZIPT||Mr|Name11|Name21
-          >002|KARN0000088|ARN|Agent3||Mr|Name1|Name2|BN12 4XL|XDLD00000100001|ZLD|||Mr|Name12|Name22
+          >002|KARN0000086|ARN|Agent Reference Number(ARN)|7|Company|Agent1||||BN12 4XL|GB|XMAP00000100051|ZAPD|Air Passenger Duty (APD)|7|Limited Company|Organisation2||||BN12 4XL|GB
+          >002|KARN0000086|ARN|Agent Reference Number(ARN)|7|Company|Agent1||||BN12 4XL|GB|XRIP00000100053|ZIPT|Insurance premium tax (IPT)|1|Sole Proprietor||Mr|Name11|Name21|1234567891|IT
+          >002|KARN0000086|ARN|Agent Reference Number(ARN)|7|Company|Agent1||||BN12 4XL|GB|XSBD00440000020|ZBD|Bingo Duty (BD)|7|Limited Company|Organisation3||||BN12 4XL|GB
+          >002|KARN0000087|ARN|Agent Reference Number(ARN)|7|Company|Agent2||||BN12 4XL|GB|XTAL00000100044|ZAGL|Aggregate Levy (AGL)|7|Limited Company|Organisation1||||BN12 4XL|GB
+          >002|KARN0000087|ARN|Agent Reference Number(ARN)|7|Company|Agent2||||BN12 4XL|GB|XALF00000100019|ZLFT|Landfill Tax Registration Number|1|Sole Proprietor||Mr|Name13|Name23||RO
+          >002|KARN0000088|ARN|Agent Reference Number(ARN)|1|Sole proprietor||Mr|AGName1|AGName2||RO|XDLD00000100001|ZLD|Lottery Duty (LD)|1|Sole Proprietor||Mr|Name12|Name22||RO
           >99|AGENT_DATA|000000006
           >
         """.stripMargin('>')
 
-      EtmpAgentRecordParser.parseFile(flatFile).size shouldBe 6
+      val numberOfUniqueAgentsInTheFlatFile = 3 // as defined by unique ARNs
+      EtmpDataParser.parseFileWithAgents(flatFile).size shouldBe numberOfUniqueAgentsInTheFlatFile
     }
   }
 
 }
+

--- a/test/uk/gov/hmrc/eeitt/services/RegistrationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/services/RegistrationServiceSpec.scala
@@ -1,96 +1,96 @@
-package uk.gov.hmrc.eeitt.services
-
-import org.specs2.mock.Mockito
-import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
-import org.scalatest.{ BeforeAndAfterEach, Inspectors, LoneElement }
-import uk.gov.hmrc.eeitt.model.{ RegisterAgentRequest, _ }
-import uk.gov.hmrc.eeitt.repositories._
-import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.eeitt.model.RegistrationResponse._
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
-class RegistrationServiceSpec extends UnitSpec
-    with RegistrationRepositorySupport with EtmpAgentRepositorySupport with EtmpBusinessUserRepositorySupport
-    with BeforeAndAfterEach with ScalaFutures with LoneElement with Inspectors with IntegrationPatience with Mockito {
-
-  object TestRegistrationService extends RegistrationService {
-    val regRepository = mock[MongoRegistrationRepository]
-    regRepository.findRegistrations("1").returns(Future.successful(List(Registration("1", false, "ALLX9876543210123", "", List("LT")))))
-    regRepository.findRegistrations("3").returns(Future.successful(List()))
-    regRepository.findRegistrations("5").returns(Future.successful(List(Registration("5", true, "", "KARN9876543210123", List()))))
-    regRepository.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB")).returns(Future.successful(Right(Nil)))
-    regRepository.register(RegisterAgentRequest("3", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
-    regRepository.register(RegisterAgentRequest("5", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
-    regRepository.addRegime(Registration("1", false, "ALLX9876543210123", "", List("LT")), "LX").returns(Future.successful(Right(Nil)))
-    val userRepository = mock[MongoEtmpBusinessUsersRepository]
-    userRepository.userExists(EtmpBusinessUser("ALLX9876543210123", "ME1 9AB")).returns(Future.successful(true))
-    userRepository.userExists(EtmpBusinessUser("ALLX9876543210123", "ME1 9ABX")).returns(Future.successful(false))
-    userRepository.userExists(EtmpBusinessUser("ALLX9876543210124", "ME1 9AB")).returns(Future.successful(true))
-    val agentRepository = mock[MongoEtmpAgentRepository]
-    agentRepository.agentExists(EtmpAgent("KARN9876543210123")).returns(Future.successful(true))
-    agentRepository.agentExists(EtmpAgent("KARN9876543210124")).returns(Future.successful(false))
-    agentRepository.agentExists(EtmpAgent("KARN9876543210125")).returns(Future.successful(true))
-  }
-
-  val service = TestRegistrationService
-
-  override protected def beforeEach(): Unit = {
-    val removeBusinessUsers = agentRepo.removeAll()
-    val removeAgents = userRepo.removeAll()
-    val removeRegistrations = regRepo.removeAll()
-    await(removeAgents)
-    await(removeBusinessUsers)
-    await(removeRegistrations)
-  }
-
-  "Registering a business user with a group id which is not present in repository" should {
-    "affect a new registration record and a 'registration ok' response" in {
-      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB"))
-      response.futureValue shouldBe RESPONSE_OK
-    }
-  }
-
-  "Registering a business user with a group id which is present in repository" should {
-    "return an error if try to register another business user" in {
-      val response = service.register(RegisterRequest("1", "ALLX9876543210123", "ME1 9AB"))
-      response.futureValue shouldBe ALREADY_REGISTERED
-      //      verify(regRepository.register(RegisterRequest("3", "LX", "AL9876543210123", "ME1 9AB")), atLeastOnce())
-    }
-    "return an error if known facts do not agree with the request" in {
-      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9ABX"))
-      response.futureValue shouldBe INCORRECT_KNOWN_FACTS
-    }
-    "affect an updated registration record if the requested regime is not present and known facts agree with the request" in {
-      val response = service.register(RegisterRequest("1", "ALLX9876543210124", "ME1 9AB"))
-      response.futureValue shouldBe RESPONSE_OK
-    }
-    "return an error if already registered to an agent" in {
-      val response = service.register(RegisterRequest("5", "ALLX9876543210123", "ME1 9AB"))
-      response.futureValue shouldBe IS_AGENT
-    }
-  }
-
-  "Registering an agent with a group id which is not present in repository" should {
-    "effect a new registration record and a 'registration ok' response" in {
-      val response = service.register(RegisterAgentRequest("3", "KARN9876543210123"))
-      response.futureValue shouldBe RESPONSE_OK
-    }
-  }
-
-  "Registering an agent with a group id which is present in repository" should {
-    "return success if the group id is already registered" in {
-      val response = service.register(RegisterAgentRequest("5", "KARN9876543210123"))
-      response.futureValue shouldBe ALREADY_REGISTERED
-    }
-    "return an error if try to register another agent" in {
-      val response = service.register(RegisterAgentRequest("5", "KARN9876543210125"))
-      response.futureValue shouldBe RESPONSE_OK
-    }
-    "return an error if already registered to an agent user" in {
-      val response = service.register(RegisterAgentRequest("1", "KARN9876543210123"))
-      response.futureValue shouldBe IS_NOT_AGENT
-    }
-  }
-}
+//package uk.gov.hmrc.eeitt.services
+//
+//import org.specs2.mock.Mockito
+//import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
+//import org.scalatest.{ BeforeAndAfterEach, Inspectors, LoneElement }
+//import uk.gov.hmrc.eeitt.model.{ RegisterAgentRequest, _ }
+//import uk.gov.hmrc.eeitt.repositories._
+//import uk.gov.hmrc.play.test.UnitSpec
+//import uk.gov.hmrc.eeitt.model.RegistrationResponse._
+//
+//import scala.concurrent.ExecutionContext.Implicits.global
+//import scala.concurrent.Future
+//
+//class RegistrationServiceSpec extends UnitSpec
+//    with RegistrationRepositorySupport with EtmpAgentRepositorySupport with EtmpBusinessUserRepositorySupport
+//    with BeforeAndAfterEach with ScalaFutures with LoneElement with Inspectors with IntegrationPatience with Mockito {
+//
+//  object TestRegistrationService extends RegistrationService {
+//    val regRepository = mock[MongoRegistrationRepository]
+//    regRepository.findRegistrations("1").returns(Future.successful(List(Registration("1", false, "ALLX9876543210123", "", List("LT")))))
+//    regRepository.findRegistrations("3").returns(Future.successful(List()))
+//    regRepository.findRegistrations("5").returns(Future.successful(List(Registration("5", true, "", "KARN9876543210123", List()))))
+//    regRepository.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB")).returns(Future.successful(Right(Nil)))
+//    regRepository.register(RegisterAgentRequest("3", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
+//    regRepository.register(RegisterAgentRequest("5", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
+//    regRepository.addRegime(Registration("1", false, "ALLX9876543210123", "", List("LT")), "LX").returns(Future.successful(Right(Nil)))
+//    val userRepository = mock[MongoEtmpBusinessUsersRepository]
+//    userRepository.userExists(EtmpBusinessUser("ALLX9876543210123", "ME1 9AB")).returns(Future.successful(true))
+//    userRepository.userExists(EtmpBusinessUser("ALLX9876543210123", "ME1 9ABX")).returns(Future.successful(false))
+//    userRepository.userExists(EtmpBusinessUser("ALLX9876543210124", "ME1 9AB")).returns(Future.successful(true))
+//    val agentRepository = mock[MongoEtmpAgentRepository]
+//    agentRepository.agentExists(EtmpAgent("KARN9876543210123")).returns(Future.successful(true))
+//    agentRepository.agentExists(EtmpAgent("KARN9876543210124")).returns(Future.successful(false))
+//    agentRepository.agentExists(EtmpAgent("KARN9876543210125")).returns(Future.successful(true))
+//  }
+//
+//  val service = TestRegistrationService
+//
+//  override protected def beforeEach(): Unit = {
+//    val removeBusinessUsers = agentRepo.removeAll()
+//    val removeAgents = userRepo.removeAll()
+//    val removeRegistrations = regRepo.removeAll()
+//    await(removeAgents)
+//    await(removeBusinessUsers)
+//    await(removeRegistrations)
+//  }
+//
+//  "Registering a business user with a group id which is not present in repository" should {
+//    "affect a new registration record and a 'registration ok' response" in {
+//      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB"))
+//      response.futureValue shouldBe RESPONSE_OK
+//    }
+//  }
+//
+//  "Registering a business user with a group id which is present in repository" should {
+//    "return an error if try to register another business user" in {
+//      val response = service.register(RegisterRequest("1", "ALLX9876543210123", "ME1 9AB"))
+//      response.futureValue shouldBe ALREADY_REGISTERED
+//      //      verify(regRepository.register(RegisterRequest("3", "LX", "AL9876543210123", "ME1 9AB")), atLeastOnce())
+//    }
+//    "return an error if known facts do not agree with the request" in {
+//      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9ABX"))
+//      response.futureValue shouldBe INCORRECT_KNOWN_FACTS
+//    }
+//    "affect an updated registration record if the requested regime is not present and known facts agree with the request" in {
+//      val response = service.register(RegisterRequest("1", "ALLX9876543210124", "ME1 9AB"))
+//      response.futureValue shouldBe RESPONSE_OK
+//    }
+//    "return an error if already registered to an agent" in {
+//      val response = service.register(RegisterRequest("5", "ALLX9876543210123", "ME1 9AB"))
+//      response.futureValue shouldBe IS_AGENT
+//    }
+//  }
+//
+//  "Registering an agent with a group id which is not present in repository" should {
+//    "effect a new registration record and a 'registration ok' response" in {
+//      val response = service.register(RegisterAgentRequest("3", "KARN9876543210123"))
+//      response.futureValue shouldBe RESPONSE_OK
+//    }
+//  }
+//
+//  "Registering an agent with a group id which is present in repository" should {
+//    "return success if the group id is already registered" in {
+//      val response = service.register(RegisterAgentRequest("5", "KARN9876543210123"))
+//      response.futureValue shouldBe ALREADY_REGISTERED
+//    }
+//    "return an error if try to register another agent" in {
+//      val response = service.register(RegisterAgentRequest("5", "KARN9876543210125"))
+//      response.futureValue shouldBe RESPONSE_OK
+//    }
+//    "return an error if already registered to an agent user" in {
+//      val response = service.register(RegisterAgentRequest("1", "KARN9876543210123"))
+//      response.futureValue shouldBe IS_NOT_AGENT
+//    }
+//  }
+//}

--- a/test/uk/gov/hmrc/eeitt/services/RegistrationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/services/RegistrationServiceSpec.scala
@@ -1,96 +1,96 @@
-//package uk.gov.hmrc.eeitt.services
-//
-//import org.specs2.mock.Mockito
-//import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
-//import org.scalatest.{ BeforeAndAfterEach, Inspectors, LoneElement }
-//import uk.gov.hmrc.eeitt.model.{ RegisterAgentRequest, _ }
-//import uk.gov.hmrc.eeitt.repositories._
-//import uk.gov.hmrc.play.test.UnitSpec
-//import uk.gov.hmrc.eeitt.model.RegistrationResponse._
-//
-//import scala.concurrent.ExecutionContext.Implicits.global
-//import scala.concurrent.Future
-//
-//class RegistrationServiceSpec extends UnitSpec
-//    with RegistrationRepositorySupport with EtmpAgentRepositorySupport with EtmpBusinessUserRepositorySupport
-//    with BeforeAndAfterEach with ScalaFutures with LoneElement with Inspectors with IntegrationPatience with Mockito {
-//
-//  object TestRegistrationService extends RegistrationService {
-//    val regRepository = mock[MongoRegistrationRepository]
-//    regRepository.findRegistrations("1").returns(Future.successful(List(Registration("1", false, "ALLX9876543210123", "", List("LT")))))
-//    regRepository.findRegistrations("3").returns(Future.successful(List()))
-//    regRepository.findRegistrations("5").returns(Future.successful(List(Registration("5", true, "", "KARN9876543210123", List()))))
-//    regRepository.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB")).returns(Future.successful(Right(Nil)))
-//    regRepository.register(RegisterAgentRequest("3", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
-//    regRepository.register(RegisterAgentRequest("5", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
-//    regRepository.addRegime(Registration("1", false, "ALLX9876543210123", "", List("LT")), "LX").returns(Future.successful(Right(Nil)))
-//    val userRepository = mock[MongoEtmpBusinessUsersRepository]
-//    userRepository.userExists(EtmpBusinessUser("ALLX9876543210123", "ME1 9AB")).returns(Future.successful(true))
-//    userRepository.userExists(EtmpBusinessUser("ALLX9876543210123", "ME1 9ABX")).returns(Future.successful(false))
-//    userRepository.userExists(EtmpBusinessUser("ALLX9876543210124", "ME1 9AB")).returns(Future.successful(true))
-//    val agentRepository = mock[MongoEtmpAgentRepository]
-//    agentRepository.agentExists(EtmpAgent("KARN9876543210123")).returns(Future.successful(true))
-//    agentRepository.agentExists(EtmpAgent("KARN9876543210124")).returns(Future.successful(false))
-//    agentRepository.agentExists(EtmpAgent("KARN9876543210125")).returns(Future.successful(true))
-//  }
-//
-//  val service = TestRegistrationService
-//
-//  override protected def beforeEach(): Unit = {
-//    val removeBusinessUsers = agentRepo.removeAll()
-//    val removeAgents = userRepo.removeAll()
-//    val removeRegistrations = regRepo.removeAll()
-//    await(removeAgents)
-//    await(removeBusinessUsers)
-//    await(removeRegistrations)
-//  }
-//
-//  "Registering a business user with a group id which is not present in repository" should {
-//    "affect a new registration record and a 'registration ok' response" in {
-//      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB"))
-//      response.futureValue shouldBe RESPONSE_OK
-//    }
-//  }
-//
-//  "Registering a business user with a group id which is present in repository" should {
-//    "return an error if try to register another business user" in {
-//      val response = service.register(RegisterRequest("1", "ALLX9876543210123", "ME1 9AB"))
-//      response.futureValue shouldBe ALREADY_REGISTERED
-//      //      verify(regRepository.register(RegisterRequest("3", "LX", "AL9876543210123", "ME1 9AB")), atLeastOnce())
-//    }
-//    "return an error if known facts do not agree with the request" in {
-//      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9ABX"))
-//      response.futureValue shouldBe INCORRECT_KNOWN_FACTS
-//    }
-//    "affect an updated registration record if the requested regime is not present and known facts agree with the request" in {
-//      val response = service.register(RegisterRequest("1", "ALLX9876543210124", "ME1 9AB"))
-//      response.futureValue shouldBe RESPONSE_OK
-//    }
-//    "return an error if already registered to an agent" in {
-//      val response = service.register(RegisterRequest("5", "ALLX9876543210123", "ME1 9AB"))
-//      response.futureValue shouldBe IS_AGENT
-//    }
-//  }
-//
-//  "Registering an agent with a group id which is not present in repository" should {
-//    "effect a new registration record and a 'registration ok' response" in {
-//      val response = service.register(RegisterAgentRequest("3", "KARN9876543210123"))
-//      response.futureValue shouldBe RESPONSE_OK
-//    }
-//  }
-//
-//  "Registering an agent with a group id which is present in repository" should {
-//    "return success if the group id is already registered" in {
-//      val response = service.register(RegisterAgentRequest("5", "KARN9876543210123"))
-//      response.futureValue shouldBe ALREADY_REGISTERED
-//    }
-//    "return an error if try to register another agent" in {
-//      val response = service.register(RegisterAgentRequest("5", "KARN9876543210125"))
-//      response.futureValue shouldBe RESPONSE_OK
-//    }
-//    "return an error if already registered to an agent user" in {
-//      val response = service.register(RegisterAgentRequest("1", "KARN9876543210123"))
-//      response.futureValue shouldBe IS_NOT_AGENT
-//    }
-//  }
-//}
+package uk.gov.hmrc.eeitt.services
+
+import org.specs2.mock.Mockito
+import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
+import org.scalatest.{ BeforeAndAfterEach, Inspectors, LoneElement }
+import uk.gov.hmrc.eeitt.model.{ RegisterAgentRequest, _ }
+import uk.gov.hmrc.eeitt.repositories._
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.eeitt.model.RegistrationResponse._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RegistrationServiceSpec extends UnitSpec
+    with RegistrationRepositorySupport with EtmpAgentRepositorySupport with EtmpBusinessUserRepositorySupport
+    with BeforeAndAfterEach with ScalaFutures with LoneElement with Inspectors with IntegrationPatience with Mockito {
+
+  object TestRegistrationService extends RegistrationService {
+    val regRepository = mock[MongoRegistrationRepository]
+    regRepository.findRegistrations("1").returns(Future.successful(List(Registration("1", false, "ALLX9876543210123", "", List("LT")))))
+    regRepository.findRegistrations("3").returns(Future.successful(List()))
+    regRepository.findRegistrations("5").returns(Future.successful(List(Registration("5", true, "", "KARN9876543210123", List()))))
+    regRepository.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB")).returns(Future.successful(Right(Nil)))
+    regRepository.register(RegisterAgentRequest("3", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
+    regRepository.register(RegisterAgentRequest("5", "KARN9876543210123")).returns(Future.successful(Right(Nil)))
+    regRepository.addRegime(Registration("1", false, "ALLX9876543210123", "", List("LT")), "LX").returns(Future.successful(Right(Nil)))
+    val userRepository = mock[MongoEtmpBusinessUsersRepository]
+    userRepository.userExists("ALLX9876543210123", "ME1 9AB").returns(Future.successful(true))
+    userRepository.userExists("ALLX9876543210123", "ME1 9ABX").returns(Future.successful(false))
+    userRepository.userExists("ALLX9876543210124", "ME1 9AB").returns(Future.successful(true))
+    val agentRepository = mock[MongoEtmpAgentRepository]
+    agentRepository.agentExists("KARN9876543210123").returns(Future.successful(true))
+    agentRepository.agentExists("KARN9876543210124").returns(Future.successful(false))
+    agentRepository.agentExists("KARN9876543210125").returns(Future.successful(true))
+  }
+
+  val service = TestRegistrationService
+
+  override protected def beforeEach(): Unit = {
+    val removeBusinessUsers = agentRepo.removeAll()
+    val removeAgents = userRepo.removeAll()
+    val removeRegistrations = regRepo.removeAll()
+    await(removeAgents)
+    await(removeBusinessUsers)
+    await(removeRegistrations)
+  }
+
+  "Registering a business user with a group id which is not present in repository" should {
+    "affect a new registration record and a 'registration ok' response" in {
+      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9AB"))
+      response.futureValue shouldBe RESPONSE_OK
+    }
+  }
+
+  "Registering a business user with a group id which is present in repository" should {
+    "return an error if try to register another business user" in {
+      val response = service.register(RegisterRequest("1", "ALLX9876543210123", "ME1 9AB"))
+      response.futureValue shouldBe ALREADY_REGISTERED
+      //      verify(regRepository.register(RegisterRequest("3", "LX", "AL9876543210123", "ME1 9AB")), atLeastOnce())
+    }
+    "return an error if known facts do not agree with the request" in {
+      val response = service.register(RegisterRequest("3", "ALLX9876543210123", "ME1 9ABX"))
+      response.futureValue shouldBe INCORRECT_KNOWN_FACTS
+    }
+    "affect an updated registration record if the requested regime is not present and known facts agree with the request" in {
+      val response = service.register(RegisterRequest("1", "ALLX9876543210124", "ME1 9AB"))
+      response.futureValue shouldBe RESPONSE_OK
+    }
+    "return an error if already registered to an agent" in {
+      val response = service.register(RegisterRequest("5", "ALLX9876543210123", "ME1 9AB"))
+      response.futureValue shouldBe IS_AGENT
+    }
+  }
+
+  "Registering an agent with a group id which is not present in repository" should {
+    "effect a new registration record and a 'registration ok' response" in {
+      val response = service.register(RegisterAgentRequest("3", "KARN9876543210123"))
+      response.futureValue shouldBe RESPONSE_OK
+    }
+  }
+
+  "Registering an agent with a group id which is present in repository" should {
+    "return success if the group id is already registered" in {
+      val response = service.register(RegisterAgentRequest("5", "KARN9876543210123"))
+      response.futureValue shouldBe ALREADY_REGISTERED
+    }
+    "return an error if try to register another agent" in {
+      val response = service.register(RegisterAgentRequest("5", "KARN9876543210125"))
+      response.futureValue shouldBe RESPONSE_OK
+    }
+    "return an error if already registered to an agent user" in {
+      val response = service.register(RegisterAgentRequest("1", "KARN9876543210123"))
+      response.futureValue shouldBe IS_NOT_AGENT
+    }
+  }
+}


### PR DESCRIPTION
This PR adds parsing/importing of the full ETMP data set.

Specification of the data and sample files can be found here: https://confluence.tools.tax.service.gov.uk/display/AF/ETMP+data