### PR TITLE
Implemented explicit audit form registration and data load

### DIFF
--- a/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala
+++ b/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala
@@ -4,9 +4,11 @@ import play.api.Logger
 import play.api.libs.json.{ JsObject, Json }
 import play.api.mvc.Action
 import reactivemongo.api.commands.{ MultiBulkWriteResult, Upserted, WriteError }
+import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpBusinessUser }
 import uk.gov.hmrc.eeitt.repositories._
-import uk.gov.hmrc.eeitt.services.{ EtmpDataParser, LineParsingException }
+import uk.gov.hmrc.eeitt.services.{ AuditService, EtmpDataParser, HmrcAuditService, LineParsingException }
 import uk.gov.hmrc.eeitt.utils.NonFatalWithLogging
+import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -18,6 +20,8 @@ trait EtmpDataLoaderController extends BaseController {
   def businessUserRepo: EtmpBusinessUsersRepository
 
   def agentRepo: EtmpAgentRepository
+
+  val etmpDataLoader = new EtmpDataLoader(new HmrcAuditService)
 
   def loadBusinessUsers = {
     Logger.info("Import business users - live")
@@ -31,17 +35,17 @@ trait EtmpDataLoaderController extends BaseController {
 
   def loadBusinessUsersDryRun = {
     Logger.info("Import business users - dry-run")
-    load(EtmpDataParser.parseFileWithBusinessUsers, EtmpDataLoader.dryRun)
+    load(EtmpDataParser.parseFileWithBusinessUsers, etmpDataLoader.dryRun)
   }
 
   def loadAgentsDryRun = {
     Logger.info("Import agents - dry-run")
-    load(EtmpDataParser.parseFileWithAgents, EtmpDataLoader.dryRun)
+    load(EtmpDataParser.parseFileWithAgents, etmpDataLoader.dryRun)
   }
 
   def load[A](parseFile: String => Seq[A], replaceAll: Seq[A] => Future[MultiBulkWriteResult]) =
-    Action.async(parse.tolerantText) { request =>
-      EtmpDataLoader.load(request.body)(parseFile, replaceAll).map {
+    Action.async(parse.tolerantText) { implicit request =>
+      etmpDataLoader.load(request.body)(parseFile, replaceAll).map {
         case LoadOk(json) => Ok(json)
         case ServerFailure(json) => InternalServerError(json)
         case ParsingFailure(json) => BadRequest(json)
@@ -62,17 +66,31 @@ case class LoadOk(json: JsObject) extends EtmpDataLoaderResult
 case class ServerFailure(json: JsObject) extends EtmpDataLoaderResult
 case class ParsingFailure(json: JsObject) extends EtmpDataLoaderResult
 
-object EtmpDataLoader {
+class EtmpDataLoader(auditService: AuditService) {
 
   def dryRun[A](records: Seq[A]): Future[MultiBulkWriteResult] =
     Future.successful(MultiBulkWriteResult(true, records.size, 0, Seq.empty[Upserted], Seq.empty[WriteError], None, None, None, 0))
 
-  def load[A](requestBody: String)(parseFile: String => Seq[A], replaceAll: Seq[A] => Future[MultiBulkWriteResult]): Future[EtmpDataLoaderResult] = {
+  def load[A](requestBody: String)(parseFile: String => Seq[A], replaceAll: Seq[A] => Future[MultiBulkWriteResult])(implicit hc: HeaderCarrier): Future[EtmpDataLoaderResult] = {
     Try(parseFile(requestBody)) match {
       case Success(records @ _ :: _) =>
         replaceAll(records).map { writeResult =>
           val expectedNumberOfInserts = records.size
           if (writeResult.ok && writeResult.n == expectedNumberOfInserts) {
+            val recordCount = writeResult.n.toString
+            records.headOption.map(r => r match {
+              case e: EtmpAgent =>
+                auditService.sendDataLoadEvent("/etmp-data/live", Map {
+                  "user-type" -> "agent"
+                  "record-count" -> recordCount
+                })
+              case e: EtmpBusinessUser =>
+                auditService.sendDataLoadEvent("/etmp-data/live", Map {
+                  "user-type" -> "business-user"
+                  "record-count" -> recordCount
+                })
+              case _ =>
+            })
             LoadOk(Json.obj("message" -> s"$expectedNumberOfInserts unique objects imported successfully"))
           } else {
             ServerFailure(

--- a/app/uk/gov/hmrc/eeitt/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/eeitt/controllers/RegistrationController.scala
@@ -9,7 +9,7 @@ import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.play.microservice.controller.BaseController
 import uk.gov.hmrc.eeitt.repositories._
 import uk.gov.hmrc.eeitt.model.RegistrationResponse._
-import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.eeitt.typeclasses.{ HmrcAudit, SendRegistered }
 
 import scala.concurrent.Future
 
@@ -18,6 +18,7 @@ object RegistrationController extends RegistrationController {
   implicit lazy val agentRegistrationRepo = agentRegistrationRepository
   implicit lazy val etmpBusinessUserRepo = etmpBusinessUserRepository
   implicit lazy val etmpAgentRepo = etmpAgentRepository
+  implicit lazy val auditService = new HmrcAuditService
 
   def verification(groupId: GroupId, regimeId: RegimeId, affinityGroup: AffinityGroup) = affinityGroup match {
     case Agent =>
@@ -41,12 +42,9 @@ object RegistrationController extends RegistrationController {
   def registerBusinessUser = register[RegisterBusinessUserRequest, EtmpBusinessUser]
 
   def registerAgent = register[RegisterAgentRequest, EtmpAgent]
-
 }
 
 trait RegistrationController extends BaseController {
-
-  lazy val auditService = new HmrcAuditService
 
   def verify[A: FindRegistration](findParams: A) = Action.async { implicit request =>
     RegistrationService.findRegistration(findParams)
@@ -74,18 +72,22 @@ trait RegistrationController extends BaseController {
 
   def register[A <: RegisterRequest: Reads: AddRegistration: FindRegistration, B: PostcodeValidator](
     implicit
-    findUser: FindUser[A, B]
-  ) = Action.async(parse.json) { implicit request =>
+    findUser: FindUser[A, B],
+    sendRegistered: SendRegistered[A],
+    hmrcAudit: HmrcAudit[AuditData]
+  ): Action[JsValue] = Action.async(parse.json) { implicit request =>
+
     request.body.validate match {
       case JsSuccess(req, _) =>
-        val registerationResponse: Future[RegistrationResponse] = RegistrationService.register(req)
-        registerationResponse.map {
-          case RESPONSE_OK => {
-            sendRegisteredEvent(request, req)
-            RESPONSE_OK
-          }
-          case r => r
-        }.map(response => Ok(Json.toJson(response)))
+        RegistrationService.register(req).map {
+          case r @ RESPONSE_OK =>
+            val (postCode, tags) = sendRegistered(req)
+            val ad = new AuditData(request.path, postCode, tags)
+            hmrcAudit(ad)(hc(request))
+            Ok(Json.toJson(r))
+          case response =>
+            Ok(Json.toJson(response))
+        }
       case JsError(jsonErrors) =>
         Logger.debug(s"incorrect request: $jsonErrors ")
 
@@ -95,19 +97,7 @@ trait RegistrationController extends BaseController {
           case (JsPath(KeyPathNode("registrationNumber") :: _), _) :: _ => Ok(Json.toJson(INCORRECT_KNOWN_FACTS_BUSINESS_USERS))
           case _ => BadRequest(Json.obj("message" -> JsError.toFlatJson(jsonErrors)))
         }
-
         Future.successful(response)
-
-    }
-  }
-
-  private def sendRegisteredEvent[B: PostcodeValidator, A <: RegisterRequest: Reads: AddRegistration: FindRegistration](request: Request[JsValue], req: A)(implicit hc: HeaderCarrier) = {
-    req match {
-      case r: RegisterAgentRequest =>
-        auditService.sendRegisteredAgentEvent(request.path, r, Map("user-type" -> "agent"))
-      case r: RegisterBusinessUserRequest =>
-        auditService.sendRegisteredBusinessUserEvent(request.path, r, Map("user-type" -> "business-user"))
-      case _ =>
     }
   }
 }

--- a/app/uk/gov/hmrc/eeitt/model/AuditData.scala
+++ b/app/uk/gov/hmrc/eeitt/model/AuditData.scala
@@ -1,0 +1,3 @@
+package uk.gov.hmrc.eeitt.model
+
+class AuditData(val path: String, val postcode: Option[Postcode], val tags: Map[String, String])

--- a/app/uk/gov/hmrc/eeitt/services/HmrcAuditService.scala
+++ b/app/uk/gov/hmrc/eeitt/services/HmrcAuditService.scala
@@ -1,0 +1,60 @@
+package uk.gov.hmrc.eeitt.services
+
+import uk.gov.hmrc.eeitt.MicroserviceAuditConnector
+import uk.gov.hmrc.eeitt.model.{ Postcode, RegisterAgentRequest, RegisterBusinessUserRequest, RegisterRequest }
+import uk.gov.hmrc.play.audit.AuditExtensions._
+import uk.gov.hmrc.play.audit.model.{ Audit, DataEvent, EventTypes }
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+trait AuditService {
+
+  def sendRegisteredBusinessUserEvent(path: String, request: RegisterBusinessUserRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
+
+  def sendRegisteredAgentEvent(path: String, request: RegisterAgentRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
+
+  def sendDataLoadEvent(path: String, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
+
+}
+
+class HmrcAuditService extends AuditService {
+
+  val appName = "eeitt"
+  val audit = Audit(appName, MicroserviceAuditConnector)
+
+  def sendRegisteredBusinessUserEvent(path: String, request: RegisterBusinessUserRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
+    val requestTags = Map {
+      "registration-number" -> request.registrationNumber.value
+      "group-id" -> request.groupId.value
+      "regime-id" -> request.regimeId.value
+    }
+    sendRegisteredEvent(path, request.postcode, tags ++ requestTags)
+  }
+
+  def sendRegisteredAgentEvent(path: String, request: RegisterAgentRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
+    val requestTags = Map[String, String] {
+      "arn" -> request.arn.value
+      "group-id" -> request.groupId.value
+    }
+    sendRegisteredEvent(path, request.postcode, tags ++ requestTags)
+  }
+
+  private def sendRegisteredEvent(path: String, postcode: Option[Postcode], tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
+    val postcodeTag = postcode.map {
+      case p => ("postcode", p.value)
+    }
+    sendDataEvent("registered", path, tags ++ postcodeTag, Map.empty)
+  }
+
+  def sendDataLoadEvent(path: String, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
+    sendDataEvent("data-loaded", path, tags, Map.empty)
+  }
+
+  private def sendDataEvent(transactionName: String, path: String = "N/A", tags: Map[String, String] = Map.empty,
+    detail: Map[String, String])(implicit hc: HeaderCarrier): Unit = {
+    val event = DataEvent(appName, EventTypes.Succeeded,
+      tags = hc.toAuditTags(transactionName, path) ++ tags,
+      detail = hc.toAuditDetails(detail.toSeq: _*))
+    audit.sendDataEvent(event)
+  }
+
+}

--- a/app/uk/gov/hmrc/eeitt/services/HmrcAuditService.scala
+++ b/app/uk/gov/hmrc/eeitt/services/HmrcAuditService.scala
@@ -1,16 +1,14 @@
 package uk.gov.hmrc.eeitt.services
 
 import uk.gov.hmrc.eeitt.MicroserviceAuditConnector
-import uk.gov.hmrc.eeitt.model.{ Postcode, RegisterAgentRequest, RegisterBusinessUserRequest, RegisterRequest }
+import uk.gov.hmrc.eeitt.model.Postcode
 import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.model.{ Audit, DataEvent, EventTypes }
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 trait AuditService {
 
-  def sendRegisteredBusinessUserEvent(path: String, request: RegisterBusinessUserRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
-
-  def sendRegisteredAgentEvent(path: String, request: RegisterAgentRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
+  def sendRegisteredEvent(path: String, postcode: Option[Postcode], tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
 
   def sendDataLoadEvent(path: String, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit
 
@@ -21,27 +19,8 @@ class HmrcAuditService extends AuditService {
   val appName = "eeitt"
   val audit = Audit(appName, MicroserviceAuditConnector)
 
-  def sendRegisteredBusinessUserEvent(path: String, request: RegisterBusinessUserRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
-    val requestTags = Map {
-      "registration-number" -> request.registrationNumber.value
-      "group-id" -> request.groupId.value
-      "regime-id" -> request.regimeId.value
-    }
-    sendRegisteredEvent(path, request.postcode, tags ++ requestTags)
-  }
-
-  def sendRegisteredAgentEvent(path: String, request: RegisterAgentRequest, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
-    val requestTags = Map[String, String] {
-      "arn" -> request.arn.value
-      "group-id" -> request.groupId.value
-    }
-    sendRegisteredEvent(path, request.postcode, tags ++ requestTags)
-  }
-
-  private def sendRegisteredEvent(path: String, postcode: Option[Postcode], tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
-    val postcodeTag = postcode.map {
-      case p => ("postcode", p.value)
-    }
+  def sendRegisteredEvent(path: String, postcode: Option[Postcode], tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
+    val postcodeTag = postcode.map(p => ("postcode", p.value))
     sendDataEvent("registered", path, tags ++ postcodeTag, Map.empty)
   }
 

--- a/app/uk/gov/hmrc/eeitt/typeclasses/HmrcAudit.scala
+++ b/app/uk/gov/hmrc/eeitt/typeclasses/HmrcAudit.scala
@@ -1,0 +1,19 @@
+package uk.gov.hmrc.eeitt.typeclasses
+
+import uk.gov.hmrc.eeitt.services.HmrcAuditService
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.eeitt.model.AuditData
+
+trait HmrcAudit[A] {
+  def apply(a: A): HeaderCarrier => Unit
+}
+
+object HmrcAudit {
+  implicit def hmrcAudit(implicit auditService: HmrcAuditService): HmrcAudit[AuditData] = {
+    new HmrcAudit[AuditData] {
+      override def apply(ad: AuditData): HeaderCarrier => Unit = implicit hc => {
+        auditService.sendRegisteredEvent(ad.path, ad.postcode, ad.tags)
+      }
+    }
+  }
+}

--- a/app/uk/gov/hmrc/eeitt/typeclasses/SendDataLoad.scala
+++ b/app/uk/gov/hmrc/eeitt/typeclasses/SendDataLoad.scala
@@ -1,0 +1,23 @@
+package uk.gov.hmrc.eeitt.typeclasses
+
+import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpBusinessUser }
+
+trait SendDataLoadEvent[A] {
+  def apply(numberOfRecords: Int): Map[String, String]
+}
+
+object SendDataLoadEvent {
+  implicit object agent extends SendDataLoadEvent[EtmpAgent] {
+    def apply(numberOfRecords: Int) = Map(
+      "user-type" -> "agent",
+      "record-count" -> numberOfRecords.toString
+    )
+  }
+
+  implicit object businessUser extends SendDataLoadEvent[EtmpBusinessUser] {
+    def apply(numberOfRecords: Int) = Map(
+      "user-type" -> "business-user",
+      "record-count" -> numberOfRecords.toString
+    )
+  }
+}

--- a/app/uk/gov/hmrc/eeitt/typeclasses/SendRegistered.scala
+++ b/app/uk/gov/hmrc/eeitt/typeclasses/SendRegistered.scala
@@ -1,0 +1,33 @@
+package uk.gov.hmrc.eeitt.typeclasses
+
+import uk.gov.hmrc.eeitt.model.{ Postcode, RegisterAgentRequest, RegisterBusinessUserRequest }
+
+trait SendRegistered[A] {
+  def apply(a: A): (Option[Postcode], Map[String, String])
+}
+
+object SendRegistered {
+
+  implicit object agent extends SendRegistered[RegisterAgentRequest] {
+    override def apply(request: RegisterAgentRequest): (Option[Postcode], Map[String, String]) = {
+      val requestTags = Map(
+        "user-type" -> "agent",
+        "arn" -> request.arn.value,
+        "group-id" -> request.groupId.value
+      )
+      (request.postcode, requestTags)
+    }
+  }
+
+  implicit object businessUserv extends SendRegistered[RegisterBusinessUserRequest] {
+    override def apply(request: RegisterBusinessUserRequest): (Option[Postcode], Map[String, String]) = {
+      val requestTags = Map(
+        "user-type" -> "business-user",
+        "registration-number" -> request.registrationNumber.value,
+        "group-id" -> request.groupId.value,
+        "regime-id" -> request.regimeId.value
+      )
+      (request.postcode, requestTags)
+    }
+  }
+}

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -57,7 +57,7 @@ private object AppDependencies {
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "uk.gov.hmrc" %% "reactivemongo-test" % reactiveMongoTestVersion % scope,
         "com.typesafe.akka" %% "akka-testkit" % "2.3.2" % "test",
-        "org.mockito" % "mockito-all" % "1.9.5" % "test"
+        "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test"
       )
     }.test
   }

--- a/test/uk/gov/hmrc/eeitt/TypeclassesFixtures.scala
+++ b/test/uk/gov/hmrc/eeitt/TypeclassesFixtures.scala
@@ -1,32 +1,103 @@
 package uk.gov.hmrc.eeitt
 
 import scala.concurrent.Future
+import uk.gov.hmrc.eeitt.model.AuditData
 import uk.gov.hmrc.eeitt.services.{ AddRegistration, FindRegistration, FindUser }
+import uk.gov.hmrc.eeitt.typeclasses.HmrcAudit
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.eeitt.checks.{ AddRegistrationCheck, AuditCheck, FindRegistrationCheck, FindUserCheck }
 
 trait TypeclassFixtures {
-  def findRegistration[A, B](returnValue: List[B])(checks: A => Unit) =
-    new FindRegistration[A] {
+  class FindRegistrationTC[B](callCheck: Option[FindRegistrationCheck], returnValue: List[B]) {
+    def callCheck(callCheck: FindRegistrationCheck) = new FindRegistrationTC(Some(callCheck), returnValue)
+    def response(r: List[B]) = new FindRegistrationTC(callCheck, r)
+
+    def withChecks[A](f: A => Unit) = getTC(Some(f))
+    def noChecks[A] = getTC[A](None)
+
+    private def getTC[A](checkFn: Option[A => Unit] = None): FindRegistration.Aux[A, B] = new FindRegistration[A] {
       type Out = B
       def apply(req: A): Future[List[B]] = {
-        checks(req)
+        callCheck.foreach(_.call())
+        checkFn.foreach(_(req))
         Future.successful(returnValue)
       }
     }
+  }
 
-  def findUser[A, B](returnValue: List[B])(checks: A => Unit): FindUser[A, B] =
-    new FindUser[A, B] {
+  object FindRegistrationTC {
+    def callCheck[A](callCheck: FindRegistrationCheck) = new FindRegistrationTC(Some(callCheck), List.empty[A])
+    def response[A](r: List[A]) = new FindRegistrationTC(None, r)
+
+    def noChecks[A] = new FindRegistrationTC(None, List.empty[A]).noChecks[A]
+    def withChecks[A](f: A => Unit) = new FindRegistrationTC(None, List.empty[A]).withChecks(f)
+  }
+
+  class FindUserTC[B](callCheck: Option[FindUserCheck], returnValue: List[B]) {
+    def callCheck(callCheck: FindUserCheck) = new FindUserTC(Some(callCheck), returnValue)
+    def response(r: List[B]) = new FindUserTC(callCheck, r)
+
+    def withChecks[A](f: A => Unit) = getTC(Some(f))
+    def noChecks[A] = getTC[A](None)
+
+    private def getTC[A](checkFn: Option[A => Unit] = None): FindUser[A, B] = new FindUser[A, B] {
       def apply(req: A): Future[List[B]] = {
-        checks(req)
+        callCheck.foreach(_.call())
+        checkFn.foreach(_(req))
         Future.successful(returnValue)
       }
     }
+  }
 
-  def addRegistration[A](returnValue: Either[String, Unit])(checks: A => Unit): AddRegistration[A] =
-    new AddRegistration[A] {
+  object FindUserTC {
+    def callCheck[A](callCheck: FindUserCheck) = new FindUserTC(Some(callCheck), List.empty[A])
+    def response[A](r: List[A]) = new FindUserTC(None, r)
+
+    def noChecks[A, B] = new FindUserTC(None, List.empty[B]).noChecks[A]
+    def withChecks[A, B](f: A => Unit) = new FindUserTC(None, List.empty[B]).withChecks(f)
+  }
+
+  class AddRegistrationTC(callCheck: Option[AddRegistrationCheck], returnValue: Either[String, Unit]) {
+    def callCheck(callCheck: AddRegistrationCheck) = new AddRegistrationTC(Some(callCheck), returnValue)
+    def response(r: Either[String, Unit]) = new AddRegistrationTC(callCheck, r)
+
+    def withChecks[A](f: A => Unit) = getTC(Some(f))
+    def noChecks[A] = getTC[A](None)
+
+    private def getTC[A](checkFn: Option[A => Unit] = None): AddRegistration[A] = new AddRegistration[A] {
       def apply(req: A): Future[Either[String, Unit]] = {
-        checks(req)
+        callCheck.foreach(_.call())
+        checkFn.foreach(_(req))
         Future.successful(returnValue)
       }
     }
+  }
 
+  object AddRegistrationTC {
+    def callCheck[A](callCheck: AddRegistrationCheck) = new AddRegistrationTC(Some(callCheck), Right(()))
+    def response(r: Either[String, Unit]) = new AddRegistrationTC(None, r)
+
+    def noChecks[A] = new AddRegistrationTC(None, Right(())).noChecks[A]
+    def withChecks[A](f: A => Unit) = new AddRegistrationTC(None, Right(())).withChecks(f)
+  }
+
+  class HmrcAuditTC(callCheck: Option[AuditCheck]) {
+
+    def withChecks(f: AuditData => Unit) = getTC(Some(f))
+    def noChecks = getTC(None)
+
+    private def getTC(checkFn: Option[AuditData => Unit] = None): HmrcAudit[AuditData] = new HmrcAudit[AuditData] {
+      override def apply(ad: AuditData): HeaderCarrier => Unit = hc => {
+        callCheck.foreach(_.call())
+        checkFn.foreach(_(ad))
+      }
+    }
+  }
+
+  object HmrcAuditTC {
+    def callCheck(callCheck: AuditCheck) = new HmrcAuditTC(Some(callCheck))
+
+    def noChecks = new HmrcAuditTC(None).noChecks
+    def withChecks(f: AuditData => Unit) = new HmrcAuditTC(None).withChecks(f)
+  }
 }

--- a/test/uk/gov/hmrc/eeitt/checks/TypeclassCallCheck.scala
+++ b/test/uk/gov/hmrc/eeitt/checks/TypeclassCallCheck.scala
@@ -1,0 +1,7 @@
+package uk.gov.hmrc.eeitt.checks
+
+trait TypeclassCallCheck { def call(): Unit }
+trait AuditCheck extends TypeclassCallCheck
+trait FindUserCheck extends TypeclassCallCheck
+trait AddRegistrationCheck extends TypeclassCallCheck
+trait FindRegistrationCheck extends TypeclassCallCheck

--- a/test/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderSpec.scala
@@ -4,14 +4,27 @@ import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.Json
 import reactivemongo.api.commands.{ MultiBulkWriteResult, Upserted, WriteError }
+
 import scala.concurrent.Future
-import uk.gov.hmrc.eeitt.model.EtmpBusinessUser
-import uk.gov.hmrc.eeitt.services.EtmpDataParser
+import uk.gov.hmrc.eeitt.model.{ EtmpBusinessUser, RegisterAgentRequest, RegisterBusinessUserRequest }
+import uk.gov.hmrc.eeitt.services.{ AuditService, EtmpDataParser }
+import uk.gov.hmrc.play.http.HeaderCarrier
 
 class EtmpDataLoaderSpec extends FlatSpec with Matchers with ScalaFutures {
+  implicit val hc = new HeaderCarrier()
+
+  val auditServiceStub = new AuditService {
+    override def sendRegisteredBusinessUserEvent(path: String, request: RegisterBusinessUserRequest, tags: Map[String, String])(implicit hc: HeaderCarrier): Unit = {}
+
+    override def sendRegisteredAgentEvent(path: String, request: RegisterAgentRequest, tags: Map[String, String])(implicit hc: HeaderCarrier): Unit = {}
+
+    override def sendDataLoadEvent(path: String, tags: Map[String, String])(implicit hc: HeaderCarrier): Unit = {}
+  }
+
+  val etmpDataLoader = new EtmpDataLoader(auditServiceStub)
 
   "EtmpDataLoader" should "fail to parse empty input" in {
-    val res = EtmpDataLoader.load("")(EtmpDataParser.parseFileWithBusinessUsers, EtmpDataLoader.dryRun)
+    val res = etmpDataLoader.load("")(EtmpDataParser.parseFileWithBusinessUsers, etmpDataLoader.dryRun)
     res.futureValue should be(ParsingFailure(
       Json.obj(
         "message" -> "Not a single input line was parsed correctly.",
@@ -21,7 +34,7 @@ class EtmpDataLoaderSpec extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "fail to parse invalid input" in {
-    val res = EtmpDataLoader.load("invalidInput")(EtmpDataParser.parseFileWithBusinessUsers, EtmpDataLoader.dryRun)
+    val res = etmpDataLoader.load("invalidInput")(EtmpDataParser.parseFileWithBusinessUsers, etmpDataLoader.dryRun)
     res.futureValue should be(ParsingFailure(
       Json.obj(
         "message" -> "Not a single input line was parsed correctly.",
@@ -41,7 +54,7 @@ class EtmpDataLoaderSpec extends FlatSpec with Matchers with ScalaFutures {
          |002|KARN0000088|ARN|Agent Reference Number(ARN)|1|Sole proprietor||Mr|AGName1|AGName2||RO|XDLD00000100001|ZLD|Lottery Duty (LD)|1|Sole Proprietor||Mr|Name12|Name22||RO
          |99|AGENT_DATA|000000006""".stripMargin
 
-    val res = EtmpDataLoader.load(agentData)(EtmpDataParser.parseFileWithAgents, EtmpDataLoader.dryRun)
+    val res = etmpDataLoader.load(agentData)(EtmpDataParser.parseFileWithAgents, etmpDataLoader.dryRun)
     res.futureValue should be(LoadOk(Json.obj("message" -> "3 unique objects imported successfully")))
   }
 
@@ -58,7 +71,7 @@ class EtmpDataLoaderSpec extends FlatSpec with Matchers with ScalaFutures {
          |001|XDLD00000100001|ZLD|Lottery Duty (LD)|1|Sole Proprietor||Mr|Name12|Name22||RO
          |99|CUSTOMER_DATA|000000007""".stripMargin
 
-    val res = EtmpDataLoader.load(businessUsersData)(EtmpDataParser.parseFileWithBusinessUsers, EtmpDataLoader.dryRun)
+    val res = etmpDataLoader.load(businessUsersData)(EtmpDataParser.parseFileWithBusinessUsers, etmpDataLoader.dryRun)
     res.futureValue should be(LoadOk(Json.obj("message" -> "7 unique objects imported successfully")))
   }
 
@@ -69,7 +82,7 @@ class EtmpDataLoaderSpec extends FlatSpec with Matchers with ScalaFutures {
          |001|XTAL00000100
          |99|CUSTOMER_DATA|000000007""".stripMargin
 
-    val res = EtmpDataLoader.load(corruptedData)(EtmpDataParser.parseFileWithBusinessUsers, EtmpDataLoader.dryRun)
+    val res = etmpDataLoader.load(corruptedData)(EtmpDataParser.parseFileWithBusinessUsers, etmpDataLoader.dryRun)
     res.futureValue should be(ParsingFailure(Json.obj("message" -> "Failed to parse due to unexpected format of line: 001|XTAL00000100")))
   }
 
@@ -86,7 +99,7 @@ class EtmpDataLoaderSpec extends FlatSpec with Matchers with ScalaFutures {
     val updateZeroRecords: Seq[EtmpBusinessUser] => Future[MultiBulkWriteResult] = _ =>
       Future.successful(MultiBulkWriteResult(true, 2, 0, Seq.empty[Upserted], Seq.empty[WriteError], None, None, None, 0))
 
-    val res = EtmpDataLoader.load(businessUsersData)(EtmpDataParser.parseFileWithBusinessUsers, updateZeroRecords)
+    val res = etmpDataLoader.load(businessUsersData)(EtmpDataParser.parseFileWithBusinessUsers, updateZeroRecords)
     res.futureValue should be(ServerFailure(Json.obj(
       "message" -> "Replaced existing records but failed to insert 2 records out of 4 in input",
       "details" -> "MultiBulkWriteResult(true,2,0,List(),List(),None,None,None,0)"

--- a/test/uk/gov/hmrc/eeitt/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/controllers/RegistrationControllerSpec.scala
@@ -1,27 +1,28 @@
 package uk.gov.hmrc.eeitt.controllers
 
-import org.scalatest.{ AppendedClues, Inside }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.Inside
 import play.api.http.Status
-import play.api.libs.json.{ JsObject, Json }
+import play.api.libs.json.Json
 import play.api.libs.json.Json._
 import play.api.test.{ FakeRequest, Helpers }
-import uk.gov.hmrc.eeitt.services.PrepopulationData
+import uk.gov.hmrc.eeitt.typeclasses.HmrcAudit
 import uk.gov.hmrc.eeitt.{ EtmpFixtures, RegistrationFixtures, TypeclassFixtures }
 import uk.gov.hmrc.eeitt.model.RegistrationResponse._
 import uk.gov.hmrc.eeitt.model.{ VerificationResponse, _ }
-import uk.gov.hmrc.eeitt.services.{ FindRegistration, RegistrationService }
+import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.{ UnitSpec, WithFakeApplication }
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.eeitt.checks._
 
-import scala.concurrent.Future
-
-class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with AppendedClues with Inside with EtmpFixtures with RegistrationFixtures with TypeclassFixtures {
+class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with Inside with EtmpFixtures with RegistrationFixtures with TypeclassFixtures with ScalaFutures with MockFactory {
 
   object TestRegistrationController extends RegistrationController {}
 
   "GET /group-identifier/:gid/regimes/:regimeid/verification" should {
     "return 200 and is allowed for successful registration lookup where regime is authorised" in {
       val fakeRequest = FakeRequest()
-      implicit val a = findRegistration(List(testRegistrationBusinessUser())) { req: (GroupId, RegimeId) => }
+      implicit val a = FindRegistrationTC.response(List(testRegistrationBusinessUser())).noChecks[(GroupId, RegimeId)]
       val action = TestRegistrationController.verify((GroupId("1"), RegimeId("ZZ")))
       val result = action(fakeRequest)
       status(result) shouldBe Status.OK
@@ -30,7 +31,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
 
     "return 200 and is not allowed for successful registration lookup where regime is not authorised" in {
       val fakeRequest = FakeRequest()
-      implicit val a = findRegistration(List.empty[RegistrationBusinessUser]) { req: (GroupId, RegimeId) => }
+      implicit val a = FindRegistrationTC.response(List.empty[RegistrationBusinessUser]).noChecks[(GroupId, RegimeId)]
       val action = TestRegistrationController.verify((GroupId("1"), RegimeId("ZZ")))
       val result = action(fakeRequest)
       status(result) shouldBe Status.OK
@@ -39,7 +40,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
 
     "return 200 and is not allowed for a lookup which returned multiple registration instances" in {
       val fakeRequest = FakeRequest()
-      implicit val a = findRegistration(List(testRegistrationBusinessUser(), testRegistrationBusinessUser())) { req: (GroupId, RegimeId) => }
+      implicit val a = FindRegistrationTC.response(List(testRegistrationBusinessUser(), testRegistrationBusinessUser())).noChecks[(GroupId, RegimeId)]
 
       val action = TestRegistrationController.verify((GroupId("1"), RegimeId("ZZ")))
       val result = action(fakeRequest)
@@ -49,7 +50,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
 
     "return 200 and is allowed for successful registration lookup of agent" in {
       val fakeRequest = FakeRequest()
-      implicit val a = findRegistration(List(testRegistrationAgent())) { req: GroupId => }
+      implicit val a = FindRegistrationTC.response(List(testRegistrationAgent())).noChecks[GroupId]
       val action = TestRegistrationController.verify(GroupId("1"))
       val result = action(fakeRequest)
       status(result) shouldBe Status.OK
@@ -59,13 +60,121 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
 
   "POST /eeitt-auth/register" should {
 
-    "return 200 and error if submitted known facts are different than stored known facts about business user" in {
+    "Register business user and send audit change" in {
+
+      val hmrcAuditCheck = mock[AuditCheck]
+      val findUserCheck = mock[FindUserCheck]
+      val addRegistrationCheck = mock[AddRegistrationCheck]
+      val findRegistrationCheck = mock[FindRegistrationCheck]
+
       val fakeRequest = FakeRequest(Helpers.POST, "/register").withBody(toJson(RegisterBusinessUserRequest(GroupId("1"), RegistrationNumber("1234567890ABCDE"), Some(Postcode("SE39EPX")))))
 
-      implicit val a = addRegistration(Right(())) { req: RegisterBusinessUserRequest => /* is not called */ }
-      implicit val b = findRegistration(List.empty[RegisterBusinessUserRequest]) { req: RegisterBusinessUserRequest => /* is not called */ }
+      implicit val a = AddRegistrationTC
+        .callCheck(addRegistrationCheck)
+        .response(Right(()))
+        .noChecks[RegisterBusinessUserRequest]
 
-      implicit val c = findUser(List.empty[EtmpBusinessUser]) { req: RegisterBusinessUserRequest =>
+      implicit val b = FindRegistrationTC
+        .callCheck(findRegistrationCheck)
+        .noChecks[RegisterBusinessUserRequest]
+
+      implicit val c = FindUserTC
+        .callCheck(findUserCheck)
+        .response(List(testEtmpBusinessUser()))
+        .withChecks { req: RegisterBusinessUserRequest =>
+          inside(req) {
+            case RegisterBusinessUserRequest(groupId, registrationNumber, postcode) =>
+              groupId.value should be("1")
+              registrationNumber.value should be("1234567890ABCDE")
+              convertOptionToValuable(postcode).value.value should be("SE39EPX")
+          }
+        }
+
+      implicit val d = HmrcAuditTC
+        .callCheck(hmrcAuditCheck)
+        .withChecks { ad =>
+          ad.path should be("/register")
+          ad.postcode.map(_.value) should be(Some("SE39EPX"))
+
+          ad.tags should contain("user-type" -> "business-user")
+          ad.tags should contain("registration-number" -> "1234567890ABCDE")
+          ad.tags should contain("group-id" -> "1")
+          ad.tags should contain("regime-id" -> "34")
+        }
+
+      (hmrcAuditCheck.call _).expects().once
+      (findUserCheck.call _).expects().once
+      (addRegistrationCheck.call _).expects().once
+      (findRegistrationCheck.call _).expects().once
+
+      val action = TestRegistrationController.register[RegisterBusinessUserRequest, EtmpBusinessUser]
+      val result = action(fakeRequest)
+      status(result) shouldBe Status.OK
+      jsonBodyOf(await(result)) shouldBe toJson(RESPONSE_OK)
+    }
+
+    "Register agent and send audit change" in {
+
+      val hmrcAuditCheck = mock[AuditCheck]
+      val findUserCheck = mock[FindUserCheck]
+      val addRegistrationCheck = mock[AddRegistrationCheck]
+      val findRegistrationCheck = mock[FindRegistrationCheck]
+
+      val fakeRequest = FakeRequest(Helpers.POST, "/register").withBody(toJson(RegisterAgentRequest(GroupId("1"), Arn("1234567890ABCDE"), Some(Postcode("SE39EPX")))))
+
+      implicit val a = AddRegistrationTC
+        .callCheck(addRegistrationCheck)
+        .response(Right(()))
+        .noChecks[RegisterAgentRequest]
+
+      implicit val b = FindRegistrationTC
+        .callCheck(findRegistrationCheck)
+        .noChecks[RegisterAgentRequest]
+
+      implicit val c = FindUserTC
+        .callCheck(findUserCheck)
+        .response(List(testEtmpAgent()))
+        .withChecks { req: RegisterAgentRequest =>
+          inside(req) {
+            case RegisterAgentRequest(groupId, arn, postcode) =>
+              groupId.value should be("1")
+              arn.value should be("1234567890ABCDE")
+              convertOptionToValuable(postcode).value.value should be("SE39EPX")
+          }
+        }
+
+      implicit val d = HmrcAuditTC
+        .callCheck(hmrcAuditCheck)
+        .withChecks { ad =>
+          ad.path should be("/register")
+          ad.postcode.map(_.value) should be(Some("SE39EPX"))
+
+          ad.tags should contain("user-type" -> "agent")
+          ad.tags should contain("arn" -> "1234567890ABCDE")
+          ad.tags should contain("group-id" -> "1")
+        }
+
+      (hmrcAuditCheck.call _).expects().once
+      (findUserCheck.call _).expects().once
+      (addRegistrationCheck.call _).expects().once
+      (findRegistrationCheck.call _).expects().once
+
+      val action = TestRegistrationController.register[RegisterAgentRequest, EtmpAgent]
+      val result = action(fakeRequest)
+      status(result) shouldBe Status.OK
+      jsonBodyOf(await(result)) shouldBe toJson(RESPONSE_OK)
+    }
+
+    "return 200 and error if submitted known facts are different than stored known facts about business user" in {
+
+      val hmrcAuditCheck = mock[AuditCheck]
+
+      val fakeRequest = FakeRequest(Helpers.POST, "/register").withBody(toJson(RegisterBusinessUserRequest(GroupId("1"), RegistrationNumber("1234567890ABCDE"), Some(Postcode("SE39EPX")))))
+
+      implicit val a = AddRegistrationTC.response(Right(())).noChecks[RegisterBusinessUserRequest]
+      implicit val b = FindRegistrationTC.response(List.empty[RegisterBusinessUserRequest]).noChecks[RegisterBusinessUserRequest]
+
+      implicit val c = FindUserTC.response(List.empty[EtmpBusinessUser]).withChecks { req: RegisterBusinessUserRequest =>
         inside(req) {
           case RegisterBusinessUserRequest(groupId, registrationNumber, postcode) =>
             groupId.value should be("1")
@@ -73,6 +182,10 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
             convertOptionToValuable(postcode).value.value should be("SE39EPX")
         }
       }
+
+      implicit val d = HmrcAuditTC.callCheck(hmrcAuditCheck).noChecks
+
+      (hmrcAuditCheck.call _).expects().never
 
       val action = TestRegistrationController.register[RegisterBusinessUserRequest, EtmpBusinessUser]
       val result = action(fakeRequest)
@@ -83,15 +196,21 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
     "return 200 and error if submitted known facts are different than stored known facts about agent" in {
       val fakeRequest = FakeRequest(Helpers.POST, "/register").withBody(toJson(RegisterAgentRequest(GroupId("1"), Arn("12LT009"), Some(Postcode("SE39EPX")))))
 
-      implicit val a = addRegistration(Right(())) { req: RegisterAgentRequest => /* is not called */ }
-      implicit val b = findRegistration(List.empty[RegisterAgentRequest]) { req: RegisterAgentRequest => /* is not called */ }
+      implicit val a = AddRegistrationTC.response(Right(())).noChecks[RegisterAgentRequest]
+      implicit val b = FindRegistrationTC.response(List.empty[RegisterAgentRequest]).noChecks[RegisterAgentRequest]
 
-      implicit val c = findUser(List.empty[EtmpAgent]) { req: RegisterAgentRequest =>
+      implicit val c = FindUserTC.response(List.empty[EtmpAgent]).withChecks { req: RegisterAgentRequest =>
         inside(req) {
           case RegisterAgentRequest(groupId, arn, postcode) =>
             groupId.value should be("1")
             arn.value should be("12LT009")
             convertOptionToValuable(postcode).value.value should be("SE39EPX")
+        }
+      }
+
+      implicit val d = new HmrcAudit[AuditData] {
+        override def apply(ad: AuditData): HeaderCarrier => Unit = hc => {
+          ()
         }
       }
 
@@ -104,9 +223,10 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
     "return 400 and error if submitted known facts are different than stored known facts about agent" in {
       val fakeRequest = FakeRequest(Helpers.POST, "/register").withBody(Json.obj("invalid-request-json" -> "dummy"))
 
-      implicit val a = addRegistration(Right(())) { req: RegisterAgentRequest => /* is not called */ }
-      implicit val b = findRegistration(List.empty[RegisterAgentRequest]) { req: RegisterAgentRequest => /* is not called */ }
-      implicit val c = findUser(List.empty[EtmpAgent]) { req: RegisterAgentRequest => /* is not called */ }
+      implicit val a = AddRegistrationTC.response(Right(())).noChecks[RegisterAgentRequest]
+      implicit val b = FindRegistrationTC.response(List.empty[RegisterAgentRequest]).noChecks[RegisterAgentRequest]
+      implicit val c = FindUserTC.response(List.empty[EtmpAgent]).noChecks[RegisterAgentRequest]
+      implicit val d = HmrcAuditTC.noChecks
 
       val action = TestRegistrationController.register[RegisterAgentRequest, EtmpAgent]
       val result = action(fakeRequest)
@@ -118,7 +238,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
     "return arn for agent" in {
       val fakeRequest = FakeRequest()
       val agent = testRegistrationAgent()
-      implicit val a = findRegistration(List(agent)) { req: GroupId => }
+      implicit val a = FindRegistrationTC.response(List(agent)).noChecks[GroupId]
       val action = TestRegistrationController.prepopulate[GroupId, RegistrationAgent](GroupId("1"))
       val result = action(fakeRequest)
       status(result) shouldBe Status.OK
@@ -127,7 +247,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
 
     "return 404 where arn for agent is not found in db" in {
       val fakeRequest = FakeRequest()
-      implicit val a = findRegistration(List.empty[RegistrationAgent]) { req: GroupId => }
+      implicit val a = FindRegistrationTC.response(List.empty[RegistrationAgent]).noChecks[GroupId]
       val action = TestRegistrationController.prepopulate[GroupId, RegistrationAgent](GroupId("1"))
       val result = action(fakeRequest)
       status(result) shouldBe Status.NOT_FOUND
@@ -138,7 +258,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
       val fakeRequest = FakeRequest()
       val agent1 = testRegistrationAgent()
       val agent2 = testRegistrationAgent()
-      implicit val a = findRegistration(List(agent1, agent2)) { req: GroupId => }
+      implicit val a = FindRegistrationTC.response(List(agent1, agent2)).noChecks[GroupId]
       val action = TestRegistrationController.prepopulate[GroupId, RegistrationAgent](GroupId("1"))
       val result = action(fakeRequest)
       status(result) shouldBe Status.OK
@@ -148,7 +268,7 @@ class RegistrationControllerSpec extends UnitSpec with WithFakeApplication with 
     "return registrationNumber for business user" in {
       val fakeRequest = FakeRequest()
       val businessUser = testRegistrationBusinessUser()
-      implicit val a = findRegistration(List(businessUser)) { req: (GroupId, RegimeId) => }
+      implicit val a = FindRegistrationTC.response(List(businessUser)).noChecks[(GroupId, RegimeId)]
       val action = TestRegistrationController.prepopulate[(GroupId, RegimeId), RegistrationBusinessUser]((GroupId("1"), RegimeId("ZZ")))
       val result = action(fakeRequest)
       status(result) shouldBe Status.OK

--- a/test/uk/gov/hmrc/eeitt/services/RegistrationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/services/RegistrationServiceSpec.scala
@@ -8,13 +8,11 @@ import uk.gov.hmrc.eeitt.{ EtmpFixtures, RegistrationFixtures, TypeclassFixtures
 import uk.gov.hmrc.eeitt.model._
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.eeitt.model.RegistrationResponse._
-import uk.gov.hmrc.eeitt.utils.CountryCodes
 import uk.gov.hmrc.eeitt.repositories.RegistrationAgentRepository
 import uk.gov.hmrc.eeitt.repositories.RegistrationRepository
 import uk.gov.hmrc.eeitt.repositories.EtmpAgentRepository
 import uk.gov.hmrc.eeitt.repositories.EtmpBusinessUsersRepository
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedClues with EtmpFixtures with RegistrationFixtures with TypeclassFixtures {
@@ -26,15 +24,15 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
 
       val request = RegisterBusinessUserRequest(GroupId("3"), RegistrationNumber("ALLX9876543210123"), Some(Postcode("BN12 4XL")))
 
-      implicit val a = findUser(List(testEtmpBusinessUser())) { req: RegisterBusinessUserRequest =>
+      implicit val a = FindUserTC.response(List(testEtmpBusinessUser())).withChecks { req: RegisterBusinessUserRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List.empty[RegistrationBusinessUser]) { req: RegisterBusinessUserRequest =>
+      implicit val b = FindRegistrationTC.response(List.empty[RegistrationBusinessUser]).withChecks { req: RegisterBusinessUserRequest =>
         req should be(request) withClue "in findRegistration"
       }
 
-      implicit val c = addRegistration(Right(())) { req: RegisterBusinessUserRequest =>
+      implicit val c = AddRegistrationTC.response(Right(())).withChecks { req: RegisterBusinessUserRequest =>
         req should be(request) withClue "in addRegistration"
       }
 
@@ -49,15 +47,15 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
       val request = RegisterBusinessUserRequest(GroupId("3"), RegistrationNumber("ALLX9876543210123"), Some(Postcode("BN12 4XL")))
       val existingRegistration = RegistrationBusinessUser(GroupId(""), RegistrationNumber(""), RegimeId(""))
 
-      implicit val a = findUser(List(testEtmpBusinessUser())) { req: RegisterBusinessUserRequest =>
+      implicit val a = FindUserTC.response(List(testEtmpBusinessUser())).withChecks { req: RegisterBusinessUserRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List(existingRegistration)) { req: RegisterBusinessUserRequest =>
+      implicit val b = FindRegistrationTC.response(List(existingRegistration)).withChecks { req: RegisterBusinessUserRequest =>
         req should be(request) withClue "in findRegistration"
       }
 
-      implicit val c = addRegistration(Right(())) { req: RegisterBusinessUserRequest => /* is not called */ }
+      implicit val c = AddRegistrationTC.response(Right(())).noChecks[RegisterBusinessUserRequest]
 
       val response = RegistrationService.register[RegisterBusinessUserRequest, EtmpBusinessUser](request)
       response.futureValue should be(ALREADY_REGISTERED)
@@ -67,12 +65,12 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
 
       val request = RegisterBusinessUserRequest(GroupId("3"), RegistrationNumber("ALLX9876543210123"), Some(Postcode("ME1 9AB")))
 
-      implicit val a = findUser(List.empty[EtmpBusinessUser]) { req: RegisterBusinessUserRequest =>
+      implicit val a = FindUserTC.response(List.empty[EtmpBusinessUser]).withChecks { req: RegisterBusinessUserRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List.empty[RegistrationBusinessUser]) { req: RegisterBusinessUserRequest => /* is not called */ }
-      implicit val c = addRegistration(Right(())) { req: RegisterBusinessUserRequest => /* is not called */ }
+      implicit val b = FindRegistrationTC.response(List.empty[RegistrationBusinessUser]).noChecks[RegisterBusinessUserRequest]
+      implicit val c = AddRegistrationTC.response(Right(())).noChecks[RegisterBusinessUserRequest]
 
       val response = RegistrationService.register[RegisterBusinessUserRequest, EtmpBusinessUser](request)
       response.futureValue should be(INCORRECT_KNOWN_FACTS_BUSINESS_USERS)
@@ -85,15 +83,15 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
       val request = RegisterAgentRequest(GroupId("3"), Arn("ALLX9876543210123"), Some(Postcode("BN12 4XL")))
       val existingRegistration = RegistrationAgent(GroupId(""), Arn(""))
 
-      implicit val a = findUser(List(testEtmpAgent())) { req: RegisterAgentRequest =>
+      implicit val a = FindUserTC.response(List(testEtmpAgent())).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List(existingRegistration)) { req: RegisterAgentRequest =>
+      implicit val b = FindRegistrationTC.response(List(existingRegistration)).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findRegistration"
       }
 
-      implicit val c = addRegistration(Right(())) { req: RegisterAgentRequest => /* is not called */ }
+      implicit val c = AddRegistrationTC.response(Right(())).noChecks[RegisterAgentRequest]
 
       val response = RegistrationService.register[RegisterAgentRequest, EtmpAgent](request)
       response.futureValue should be(ALREADY_REGISTERED)
@@ -103,12 +101,12 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
 
       val request = RegisterAgentRequest(GroupId("3"), Arn("ALLX9876543210123"), Some(Postcode("ME1 9AB")))
 
-      implicit val a = findUser(List.empty[EtmpAgent]) { req: RegisterAgentRequest =>
+      implicit val a = FindUserTC.response(List.empty[EtmpAgent]).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List.empty[RegistrationAgent]) { req: RegisterAgentRequest => /* is not called */ }
-      implicit val c = addRegistration(Right(())) { req: RegisterAgentRequest => /* is not called */ }
+      implicit val b = FindRegistrationTC.response(List.empty[RegistrationAgent]).noChecks[RegisterAgentRequest]
+      implicit val c = AddRegistrationTC.response(Right(())).noChecks[RegisterAgentRequest]
 
       val response = RegistrationService.register[RegisterAgentRequest, EtmpAgent](request)
       response.futureValue should be(INCORRECT_KNOWN_FACTS_AGENTS)
@@ -118,15 +116,15 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
 
       val request = RegisterAgentRequest(GroupId("3"), Arn("ALLX9876543210123"), Some(Postcode("BN12 4XL")))
 
-      implicit val a = findUser(List(testEtmpAgent())) { req: RegisterAgentRequest =>
+      implicit val a = FindUserTC.response(List(testEtmpAgent())).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List.empty) { req: RegisterAgentRequest =>
+      implicit val b = FindRegistrationTC.response(List.empty).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findRegistration"
       }
 
-      implicit val c = addRegistration(Left("failed-to-add-registration")) { req: RegisterAgentRequest =>
+      implicit val c = AddRegistrationTC.response(Left("failed-to-add-registration")).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in addRegistration"
       }
 
@@ -140,15 +138,15 @@ class RegistrationServiceSpec extends UnitSpec with ScalaFutures with AppendedCl
 
       val existingRegistration = RegistrationAgent(GroupId(""), Arn(""))
 
-      implicit val a = findUser(List(testEtmpAgent())) { req: RegisterAgentRequest =>
+      implicit val a = FindUserTC.response(List(testEtmpAgent())).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findUser"
       }
 
-      implicit val b = findRegistration(List(existingRegistration, existingRegistration)) { req: RegisterAgentRequest =>
+      implicit val b = FindRegistrationTC.response(List(existingRegistration, existingRegistration)).withChecks { req: RegisterAgentRequest =>
         req should be(request) withClue "in findRegistration"
       }
 
-      implicit val c = addRegistration(Right(())) { req: RegisterAgentRequest => }
+      implicit val c = AddRegistrationTC.response(Right(())).noChecks[RegisterAgentRequest]
 
       val response = RegistrationService.register[RegisterAgentRequest, EtmpAgent](request)
       response.futureValue should be(MULTIPLE_FOUND)

--- a/test/uk/gov/hmrc/eeitt/typeclasses/HmrcAuditSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/typeclasses/HmrcAuditSpec.scala
@@ -1,0 +1,25 @@
+package uk.gov.hmrc.eeitt.typeclasses
+
+import org.scalatest._
+import uk.gov.hmrc.eeitt.model.{ AuditData, EtmpAgent, EtmpBusinessUser, Postcode }
+import uk.gov.hmrc.eeitt.services.{ AuditService, HmrcAuditService }
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+class HmrcAuditSpec extends FlatSpec with Matchers with OptionValues {
+  "HmrcAuditSpec" should "prepare audit data for EtmpAgent" in {
+
+    implicit val etmpAgentRepo = new HmrcAuditService {
+      override def sendRegisteredEvent(path: String, postcode: Option[Postcode], tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = {
+        path should be("/path")
+        postcode.value.value should be("123")
+        tags should contain("user-type" -> "agent")
+        ()
+      }
+
+      override def sendDataLoadEvent(path: String, tags: Map[String, String] = Map.empty)(implicit hc: HeaderCarrier): Unit = ()
+    }
+
+    val auditData = new AuditData("/path", Some(Postcode("123")), Map("user-type" -> "agent"))
+    implicitly[HmrcAudit[AuditData]].apply(auditData)(new HeaderCarrier())
+  }
+}

--- a/test/uk/gov/hmrc/eeitt/typeclasses/SendDataLoadEventSpec.scala
+++ b/test/uk/gov/hmrc/eeitt/typeclasses/SendDataLoadEventSpec.scala
@@ -1,0 +1,18 @@
+package uk.gov.hmrc.eeitt.typeclasses
+
+import org.scalatest._
+import uk.gov.hmrc.eeitt.model.{ EtmpAgent, EtmpBusinessUser }
+
+class SendDataLoadEventSpec extends FlatSpec with Matchers {
+  "SendDataLoadEvent" should "prepare audit data for EtmpAgent" in {
+    val m = implicitly[SendDataLoadEvent[EtmpAgent]].apply(10)
+    m should contain("user-type" -> "agent")
+    m should contain("record-count" -> "10")
+  }
+
+  it should "prepare audit data for EtmpBusinessUser" in {
+    val m = implicitly[SendDataLoadEvent[EtmpBusinessUser]].apply(10)
+    m should contain("user-type" -> "business-user")
+    m should contain("record-count" -> "10")
+  }
+}


### PR DESCRIPTION
I anyone knows a tidier way to handle:

            records.headOption.map(r => r match {

in 

https://github.com/hmrc/eeitt/blob/explicit-audit2/app/uk/gov/hmrc/eeitt/controllers/EtmpDataLoaderController.scala

then please feel free ...